### PR TITLE
Replace all backslashes with forward slashes in paths

### DIFF
--- a/lib/factory/UnnamedComponentFactory.ts
+++ b/lib/factory/UnnamedComponentFactory.ts
@@ -199,7 +199,7 @@ export class UnnamedComponentFactory implements IComponentFactory {
                 }
             }
 
-            var serialization = serialize ? 'require(\'' + resultingRequirePath.replace(/\\/g, '\\\\') + '\')' : null;
+            var serialization = serialize ? 'require(\'' + resultingRequirePath.replace(/\\/g, '/') + '\')' : null;
 
             var subObject;
             if (this._componentDefinition.requireElement) {


### PR DESCRIPTION
This is required to get around a node.js bug when paths start with './'
https://github.com/nodejs/node/issues/18299