### PR TITLE
Use typeof to check for functions

### DIFF
--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -137,7 +137,7 @@ class Util {
                 if (!value) {
                     value = [];
                 }
-                if (!(value instanceof Array)) {
+                if (!Array.isArray(value)) {
                     throw new Error('Values must be an array\n' + NodeUtil.inspect(param));
                 }
                 param.fixed.forEach((f: any) => value.push(f));
@@ -145,13 +145,13 @@ class Util {
         }
 
         // If the value is singular, and the value should be unique, transform the array to a single element
-        if (param.unique && param.unique.value === 'true' && value instanceof Array) {
+        if (param.unique && param.unique.value === 'true' && Array.isArray(value)) {
             value = value[0];
         }
 
         // If a param range is defined, apply the type and validate the range.
         if (param.range) {
-            if (value instanceof Array) {
+            if (Array.isArray(value)) {
                 value = value.map((e) => Util.captureType(e, param));
             } else {
                 value = Util.captureType(value, param);

--- a/lib/factory/MappedNamedComponentFactory.ts
+++ b/lib/factory/MappedNamedComponentFactory.ts
@@ -106,7 +106,7 @@ export class MappedNamedComponentFactory extends UnnamedComponentFactory {
             return new Resource(null, {
                 fields: resource.fields.reduce((fields: any[], field: any) => {
                     let mapped: any = MappedNamedComponentFactory.map(resourceScope, field, params);
-                    if (mapped instanceof Array) {
+                    if (Array.isArray(mapped)) {
                         fields = fields.concat(mapped);
                     } else {
                         fields.push(mapped);

--- a/lib/factory/UnnamedComponentFactory.ts
+++ b/lib/factory/UnnamedComponentFactory.ts
@@ -227,7 +227,7 @@ export class UnnamedComponentFactory implements IComponentFactory {
             object = subObject;
             if (!this._componentDefinition.requireNoConstructor || this._componentDefinition.requireNoConstructor.value !== 'true') {
                 if (this._constructable) {
-                    if (!(object instanceof Function)) {
+                    if (typeof object !== 'function') {
                         return reject(new Error('ConstructableComponent is not a function: ' + NodeUtil.inspect(object)
                           + "\n" + NodeUtil.inspect(this._componentDefinition)));
                     }

--- a/lib/factory/UnnamedComponentFactory.ts
+++ b/lib/factory/UnnamedComponentFactory.ts
@@ -85,7 +85,7 @@ export class UnnamedComponentFactory implements IComponentFactory {
                 })).then((elements: any[]) => {
                     var ret: any[] = [];
                     elements.forEach((element) => {
-                        if (element instanceof Array) {
+                        if (Array.isArray(element)) {
                             ret = ret.concat(element);
                         } else {
                             ret.push(element);
@@ -93,7 +93,7 @@ export class UnnamedComponentFactory implements IComponentFactory {
                     });
                     resolve(ret);
                 }).catch(reject);
-            } else if (value instanceof Array) {
+            } else if (Array.isArray(value)) {
                 return Promise.all(value.map(
                     (element) => UnnamedComponentFactory.getArgumentValue(element, componentRunner, settings)))
                     .then(resolve).catch(reject);


### PR DESCRIPTION
As unbelievable as it sounds, I was facing a `ConstructableComponent is not a function` error for something that was _clearly_ a function. Turns out my class was inheriting from `EventEmitter`, which—when running jest—deep down does not have `Function` in its prototype chain.

TL;DR: 

```javascript
class C {}
C.__proto__ = null;
C instanceof Function // false
typeof(C) === 'function' // true
```