### PR TITLE
Make all unit tests work on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Ensure line endings are consistent
+        run: git config --global core.autocrlf input
       - name: Check out repository
         uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/lib/construction/strategy/ConstructionStrategyCommonJs.ts
+++ b/lib/construction/strategy/ConstructionStrategyCommonJs.ts
@@ -77,7 +77,7 @@ export class ConstructionStrategyCommonJs implements IConstructionStrategy<any> 
     const pckg = moduleState.packageJsons[moduleState.mainModulePath];
     if (pckg) {
       if (requireName === pckg.name) {
-        const mainPath: string = Path.join(moduleState.mainModulePath, pckg.main);
+        const mainPath: string = Path.posix.join(moduleState.mainModulePath, pckg.main);
         const required = this.req(mainPath);
         if (required) {
           return required;

--- a/lib/rdf/RdfParser.ts
+++ b/lib/rdf/RdfParser.ts
@@ -54,15 +54,16 @@ export class RdfParser {
    * @returns {Promise<T>} A promise resolving to the data stream.
    */
   public static async fetchFileOrUrl(pathOrUrl: string): Promise<Readable> {
-    const colonPos: number = pathOrUrl.indexOf(':');
-    if (colonPos < 0 || pathOrUrl.startsWith('file://')) {
-      const path = colonPos < 0 ? pathOrUrl : pathOrUrl.slice(7);
-      if (!(await fs.stat(path)).isFile()) {
-        throw new Error(`Path does not refer to a valid file: ${pathOrUrl}`);
-      }
-      return createReadStream(path);
+    if (pathOrUrl.startsWith('http://') || pathOrUrl.startsWith('https://')) {
+      return <any> (await fetch(pathOrUrl)).body;
     }
-    return <any> (await fetch(pathOrUrl)).body;
+    if (pathOrUrl.startsWith('file://')) {
+      pathOrUrl = pathOrUrl.slice(7);
+    }
+    if (!(await fs.stat(pathOrUrl)).isFile()) {
+      throw new Error(`Path does not refer to a valid file: ${pathOrUrl}`);
+    }
+    return createReadStream(pathOrUrl);
   }
 
   /**

--- a/lib/rdf/RdfParser.ts
+++ b/lib/rdf/RdfParser.ts
@@ -1,4 +1,3 @@
-import * as Path from 'path';
 import type { Readable } from 'stream';
 import type * as RDF from 'rdf-js';
 import type { ParseOptions } from 'rdf-parse';
@@ -20,7 +19,8 @@ export class RdfParser {
    * @param options Parsing options.
    */
   public parse(textStream: NodeJS.ReadableStream, options: RdfParserOptions): RDF.Stream & Readable {
-    options.path = options.path.includes('://') ? options.path : Path.normalize(options.path);
+    // Parsing libraries don't work as expected if path contains backslashes
+    options.path = options.path.replace(/\\+/gu, '/');
 
     if (!options.baseIRI) {
       options.baseIRI = options.path;

--- a/lib/rdf/RdfParser.ts
+++ b/lib/rdf/RdfParser.ts
@@ -24,7 +24,8 @@ export class RdfParser {
 
     if (!options.baseIRI) {
       options.baseIRI = options.path;
-      if (!options.baseIRI.includes(':')) {
+      // Windows paths always contain a ':'
+      if (!options.baseIRI.includes(':') || /^[A-Za-z]:[/\\][^/]/u.test(options.baseIRI)) {
         options.baseIRI = `file://${options.baseIRI}`;
       }
     }

--- a/test/unit/loading/ComponentsManager-test.ts
+++ b/test/unit/loading/ComponentsManager-test.ts
@@ -97,16 +97,16 @@ describe('ComponentsManager', () => {
       });
       await expect(componentsManager.instantiate('ex:not:registered'))
         .rejects.toThrow('No config instance with IRI ex:not:registered has been registered');
-      expect(fs.writeFileSync).toHaveBeenCalledWith('componentsjs-error-state.json', `{
-  "componentResources": [],
-  "moduleState": {
-    "mainModulePath": "${mainModulePath}",
-    "componentModules": {
-      "A": "${mainModulePath}/../../assets/module.jsonld"
-    },
-    "nodeModulePaths": []
-  }
-}`, 'utf8');
+      expect(fs.writeFileSync).toHaveBeenCalledWith('componentsjs-error-state.json', JSON.stringify({
+        componentResources: [],
+        moduleState: {
+          mainModulePath,
+          componentModules: {
+            A: `${mainModulePath}/../../assets/module.jsonld`,
+          },
+          nodeModulePaths: [],
+        },
+      }, null, '  '), 'utf8');
     });
 
     it('should instantiate an existing config without options', async() => {

--- a/test/unit/loading/ModuleStateBuilder-test.ts
+++ b/test/unit/loading/ModuleStateBuilder-test.ts
@@ -1,4 +1,3 @@
-import * as Path from 'path';
 import { mocked } from 'ts-jest/utils';
 import { ModuleStateBuilder } from '../../../lib/loading/ModuleStateBuilder';
 
@@ -264,11 +263,11 @@ describe('ModuleStateBuilder', () => {
 
   describe('buildNodeModuleImportPaths', () => {
     it('should return all parent directories', () => {
-      expect(builder.buildNodeModuleImportPaths([ '', 'a', 'b', 'c', 'd' ].join(Path.sep))).toEqual([
-        [ '', 'a', 'b', 'c', 'd' ].join(Path.sep),
-        [ '', 'a', 'b', 'c' ].join(Path.sep),
-        [ '', 'a', 'b' ].join(Path.sep),
-        [ '', 'a' ].join(Path.sep),
+      expect(builder.buildNodeModuleImportPaths([ '', 'a', 'b', 'c', 'd' ].join('/'))).toEqual([
+        [ '', 'a', 'b', 'c', 'd' ].join('/'),
+        [ '', 'a', 'b', 'c' ].join('/'),
+        [ '', 'a', 'b' ].join('/'),
+        [ '', 'a' ].join('/'),
       ]);
     });
   });

--- a/test/unit/rdf/RdfParser-test.ts
+++ b/test/unit/rdf/RdfParser-test.ts
@@ -115,6 +115,16 @@ describe('RdfParser', () => {
         ]);
     });
 
+    it('for a Turtle stream with relative IRIs should resolve to default baseIRI with abs windows path', async() => {
+      const options: RdfParserOptions = {
+        path: 'C:/path/to/file.ttl',
+      };
+      expect(await arrayifyStream(parser.parse(streamifyString(`<s> <ex:p> <ex:o>.`), options)))
+        .toBeRdfIsomorphic([
+          quad('file://C:/path/to/s', 'ex:p', 'ex:o'),
+        ]);
+    });
+
     it('for a Turtle stream with relative IRIs should resolve to default baseIRI with IRI path', async() => {
       const options: RdfParserOptions = {
         path: 'http://example.org/file.ttl',


### PR DESCRIPTION
Like the title says.

Do note that this also does not do more than what the title says: this does not guarantee that everything is going to work on Windows. I tried to take most cases into account when doing the changes, but the fact is that most unit tests are only with unix paths so there might be some things missed. Might be interesting to have unit tests for both cases everywhere (or use __dirname__ when constructing paths and run tests on both systems) but that would be a more drastic undertaking.

Individual commits have some more comments on the specific changes.