### PR TITLE
Add "incorrect version number" as possible cause for remote lookup failure

### DIFF
--- a/lib/rdf/PrefetchedDocumentLoader.ts
+++ b/lib/rdf/PrefetchedDocumentLoader.ts
@@ -48,7 +48,7 @@ export class PrefetchedDocumentLoader extends FetchDocumentLoader {
 
     // Warn before doing a remote context lookup
     if (this.logger) {
-      this.logger.warn(`Detected remote context lookup for '${url}'${this.path ? ` in ${this.path}` : ''}. This may indicate a missing or invalid dependency, or an invalid context URL.`);
+      this.logger.warn(`Detected remote context lookup for '${url}'${this.path ? ` in ${this.path}` : ''}. This may indicate a missing or invalid dependency, incorrect version number, or an invalid context URL.`);
     }
     return super.load(url);
   }

--- a/test/unit/rdf/PrefetchedDocumentLoader-test.ts
+++ b/test/unit/rdf/PrefetchedDocumentLoader-test.ts
@@ -78,7 +78,7 @@ describe('PrefetchedDocumentLoader', () => {
       });
       expect(await loader.load('http://remote.org/context'))
         .toEqual({ x: 'y' });
-      expect(logger.warn).toHaveBeenCalledWith(`Detected remote context lookup for 'http://remote.org/context' in PATH. This may indicate a missing or invalid dependency, or an invalid context URL.`);
+      expect(logger.warn).toHaveBeenCalledWith(`Detected remote context lookup for 'http://remote.org/context' in PATH. This may indicate a missing or invalid dependency, incorrect version number, or an invalid context URL.`);
     });
 
     it('for a non-prefetched context with a logger without path', async() => {
@@ -91,7 +91,7 @@ describe('PrefetchedDocumentLoader', () => {
       });
       expect(await loader.load('http://remote.org/context'))
         .toEqual({ x: 'y' });
-      expect(logger.warn).toHaveBeenCalledWith(`Detected remote context lookup for 'http://remote.org/context'. This may indicate a missing or invalid dependency, or an invalid context URL.`);
+      expect(logger.warn).toHaveBeenCalledWith(`Detected remote context lookup for 'http://remote.org/context'. This may indicate a missing or invalid dependency, incorrect version number, or an invalid context URL.`);
     });
   });
 });


### PR DESCRIPTION
I wasted a bit of time trying to debug why a context.jsonld file couldn't be found - it turns out the file was at version 0.0.0 and I was looking for a version ^1.0.0.

Hopefully the change to the error message makes it clearer that this is a possible cause of the warning.