### PR TITLE
feat: fix bug and expose instantiated resource info

### DIFF
--- a/lib/ComponentsManager.ts
+++ b/lib/ComponentsManager.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import type { Resource, RdfObjectLoader } from 'rdf-object';
+import { stringToTerm } from 'rdf-string';
 import type { Logger } from 'winston';
 import type { IConfigConstructorPool } from './construction/IConfigConstructorPool';
 import type { IConstructionSettings } from './construction/IConstructionSettings';
@@ -59,6 +60,16 @@ export class ComponentsManager<Instance> {
     } catch (error: unknown) {
       throw this.generateErrorLog(error);
     }
+  }
+
+  /**
+   * Retrieve a list of all instantiated Resources.
+   */
+  public getInstantiatedResources(): Resource[] {
+    const instances = this.configConstructorPool.getInstanceRegistry();
+    return Object.keys(instances)
+      .map(key => stringToTerm(key))
+      .map(term => this.configRegistry.getInstantiatedResource(term));
   }
 
   /**

--- a/lib/construction/IConfigConstructorPool.ts
+++ b/lib/construction/IConfigConstructorPool.ts
@@ -16,4 +16,10 @@ export interface IConfigConstructorPool<Instance> {
     settings: IConstructionSettings,
   ) => Promise<Instance>;
 
+  /**
+   * Return the instance regsitry.
+   * This is a hash from registered id to a Promise of the Instance.
+   */
+  getInstanceRegistry: () => Record<string, Promise<Instance>>;
+
 }

--- a/lib/loading/ConfigRegistry.ts
+++ b/lib/loading/ConfigRegistry.ts
@@ -1,6 +1,7 @@
 import type { Readable } from 'stream';
 import type * as RDF from '@rdfjs/types';
-import type { RdfObjectLoader } from 'rdf-object';
+import type { RdfObjectLoader, Resource } from 'rdf-object';
+import { termToString } from 'rdf-string';
 import type { Logger } from 'winston';
 import { RdfParser } from '../rdf/RdfParser';
 import type { IModuleState } from './ModuleStateBuilder';
@@ -64,6 +65,14 @@ export class ConfigRegistry {
     for (const key of Object.keys(params)) {
       configResource.property[key] = this.objectLoader.createCompactedResource(`"${params[key]}"`);
     }
+  }
+
+  /**
+   * Get the instantiated Resource that was registered to the given term.
+   * @param term The term of the Resource that was instantiated
+   */
+  public getInstantiatedResource(term: RDF.Term): Resource {
+    return this.objectLoader.resources[termToString(term)];
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -43,15 +43,16 @@
     "rdf-object": "^1.13.1",
     "rdf-parse": "^2.0.0",
     "rdf-quad": "^1.5.0",
+    "rdf-string": "^1.6.0",
     "rdf-terms": "^1.7.0",
     "semver": "^7.3.2",
     "winston": "^3.3.3"
   },
   "devDependencies": {
     "@rubensworks/eslint-config": "^1.0.1",
+    "@types/jest": "^27.0.0",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
-    "@types/jest": "^27.0.0",
     "eslint": "^7.12.1",
     "eslint-config-es": "3.25.3",
     "eslint-import-resolver-typescript": "^2.3.0",

--- a/test/unit/construction/ConfigConstructorPool-test.ts
+++ b/test/unit/construction/ConfigConstructorPool-test.ts
@@ -273,6 +273,7 @@ describe('ConfigConstructorPool', () => {
             'ex:myComponentInstance': true,
           },
         });
+        await expect(pool.getInstanceRegistry()['ex:myComponentInstance']).resolves.toBe('INSTANCE0');
       });
 
       it('should create different instances by different id', async() => {
@@ -285,6 +286,8 @@ describe('ConfigConstructorPool', () => {
           types: 'ex:Component',
         }), creationSettings);
         expect(instance1).not.toBe(instance2);
+        await expect(pool.getInstanceRegistry()['ex:myComponentInstance1']).resolves.toBe('INSTANCE0');
+        await expect(pool.getInstanceRegistry()['ex:myComponentInstance2']).resolves.toBe('INSTANCE1');
       });
 
       it('should return the same instances by equal id', async() => {

--- a/test/unit/loading/ComponentsManager-test.ts
+++ b/test/unit/loading/ComponentsManager-test.ts
@@ -59,6 +59,9 @@ describe('ComponentsManager', () => {
     dumpErrorState = false;
     configConstructorPool = <any> {
       instantiate: jest.fn(() => 'INSTANCE'),
+      getInstanceRegistry: jest.fn(() => ({
+        'http://example.org/myconfig': 'INSTANCE',
+      })),
     };
     componentsManager = new ComponentsManager({
       moduleState,
@@ -130,6 +133,13 @@ describe('ComponentsManager', () => {
         componentsManager.objectLoader.resources['http://example.org/myconfig'],
         { variables: { a: 1 }},
       );
+    });
+  });
+
+  describe('getInstantiatedResources', () => {
+    it('should return an array of instantiated Resources', async() => {
+      await componentsManager.configRegistry.register(`${__dirname}/../../assets/config.jsonld`);
+      expect(componentsManager.getInstantiatedResources()).toHaveLength(1);
     });
   });
 

--- a/test/unit/loading/ConfigRegistry-test.ts
+++ b/test/unit/loading/ConfigRegistry-test.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import { RdfObjectLoader } from 'rdf-object';
+import { stringToTerm } from 'rdf-string';
 import type { Logger } from 'winston';
 import { ConfigRegistry } from '../../../lib/loading/ConfigRegistry';
 import type { IModuleState } from '../../../lib/loading/ModuleStateBuilder';
@@ -60,6 +61,14 @@ describe('ConfigRegistry', () => {
           ],
         },
       });
+    });
+  });
+
+  describe('getInstantiatedResource', () => {
+    it('can return an instantiated Resource', async() => {
+      await configRegistry.register(`${__dirname}/../../assets/config.jsonld`);
+      expect(configRegistry.getInstantiatedResource(stringToTerm('http://example.org/myconfig')).property.type.value)
+        .toBe('http://example.org/HelloWorldModule#SayHelloComponent');
     });
   });
 });


### PR DESCRIPTION
## Purpose

This PR has two purposes:

 * Exposing information about instantiated components/resources.
 * Fixing a discovered bug

## Exposing information on instantiated resources

This allows users of Componentjs to query the instantiated registry for types. In our use case this allows us to discover certain instantiated classes that implement a given interface. 

### New public methods:

* `ComponentsManager#getInstantiatedResources(): Resource[]`
* `ConfigConstructorPool#getInstanceRegistry(): Record<string, Promise<any>>`
* `ConfigRegistry#getInstantiatedResource(term: RDF.Term): Resource`

## Fixed a bug

A bug was discovered where blankNodes and literal could overwrite eachother in the internal registry. This was fixed by replacing all indexing code of `resource.value` to `termToString(resource.term)` and vice verca with `stringToTerm(resourceId)`.

A new dependency on `rdfjs-string` was added for that.