### PR TITLE
fix: improved handling of constructor arguments of type unknown.

### DIFF
--- a/test/assets/config-paramranges-unknown-boolean.jsonld
+++ b/test/assets/config-paramranges-unknown-boolean.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://linkedsoftwaredependencies.org/vocabularies/object-oriented#",
+    "ex": "http://example.org/",
+    "hello": "http://example.org/hello/"
+  },
+  "@graph": [
+    {
+      "@id": "ex:myconfig4",
+      "@type": "ex:HelloWorldModule#SayHelloComponent2",
+      "hello:key": "test",
+      "hello:value": true
+    }
+  ]
+}

--- a/test/assets/config-paramranges-unknown-number.jsonld
+++ b/test/assets/config-paramranges-unknown-number.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://linkedsoftwaredependencies.org/vocabularies/object-oriented#",
+    "ex": "http://example.org/",
+    "hello": "http://example.org/hello/"
+  },
+  "@graph": [
+    {
+      "@id": "ex:myconfig4",
+      "@type": "ex:HelloWorldModule#SayHelloComponent2",
+      "hello:key": "test",
+      "hello:value": 456
+    }
+  ]
+}

--- a/test/assets/config-paramranges-unknown-string.jsonld
+++ b/test/assets/config-paramranges-unknown-string.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "https://linkedsoftwaredependencies.org/vocabularies/object-oriented#",
+    "ex": "http://example.org/",
+    "hello": "http://example.org/hello/"
+  },
+  "@graph": [
+    {
+      "@id": "ex:myconfig4",
+      "@type": "ex:HelloWorldModule#SayHelloComponent2",
+      "hello:key": "test",
+      "hello:value": "456"
+    }
+  ]
+}

--- a/test/assets/module-paramranges-unknown.jsonld
+++ b/test/assets/module-paramranges-unknown.jsonld
@@ -1,0 +1,58 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/componentsjs/^4.0.0/components/context.jsonld",
+    {
+      "hello": "http://example.org/hello/",
+      "ex": "http://example.org/"
+    }
+  ],
+  "@graph": [
+    {
+      "@id": "ex:HelloWorldModule",
+      "@type": "Module",
+      "requireName": "helloworld",
+      "components": [
+        {
+          "@id": "ex:HelloWorldModule#SayHelloComponent2",
+          "@type": "Class",
+          "requireElement": "Hello",
+          "parameters": [
+            {
+              "@id": "hello:key",
+              "range": "xsd:string"
+            },
+            {
+              "@id": "hello:value",
+              "range": {
+                "@type": "ParameterRangeUnion",
+                "parameterRangeElements": [
+                  {
+                    "@type": "ParameterRangeWildcard"
+                  },
+                  {
+                    "@type": "ParameterRangeUndefined"
+                  }
+                ]
+              }
+            }
+          ],
+          "constructorArguments": [
+  {
+              "@id": "ex:HelloWorldModule#SayHelloComponent2_constructorArgumentsObject",
+              "fields": [
+                {
+                  "keyRaw": "key",
+                  "value": "hello:key"
+                },
+                {
+                  "keyRaw": "value",
+                  "value": "hello:value"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/integration/instantiateFile-test.ts
+++ b/test/integration/instantiateFile-test.ts
@@ -831,4 +831,52 @@ describe('construction with component configs as files', () => {
       expect(val2).toEqual('bla');
     });
   });
+
+  describe(`for a component using params of type unknown`, () => {
+    beforeEach(async() => {
+      manager = await ComponentsManager.build({
+        mainModulePath: __dirname,
+        moduleState,
+        async moduleLoader(registry) {
+          await registry.registerModule(Path.join(__dirname, '../assets/module-paramranges-unknown.jsonld'));
+        },
+      });
+    });
+
+    it('should parse numerical instantations of the unknown parameter as number.', async() => {
+      await manager.configRegistry
+        .register(Path.join(__dirname, '../assets/config-paramranges-unknown-number.jsonld'));
+      manager.logger.error = jest.fn();
+
+      const run1 = await manager.instantiate('http://example.org/myconfig4');
+      expect(run1).toBeInstanceOf(Hello);
+      const value = run1._params[0].value;
+      expect(typeof value).toBe('number');
+      expect(value).toBe(456);
+    });
+
+    it('should parse boolean instantations of the unknown parameter as boolean.', async() => {
+      await manager.configRegistry
+        .register(Path.join(__dirname, '../assets/config-paramranges-unknown-boolean.jsonld'));
+      manager.logger.error = jest.fn();
+
+      const run1 = await manager.instantiate('http://example.org/myconfig4');
+      expect(run1).toBeInstanceOf(Hello);
+      const value = run1._params[0].value;
+      expect(typeof value).toBe('boolean');
+      expect(value).toBeTruthy();
+    });
+
+    it('should parse string instantations of the unknown parameter, containing a number, as string.', async() => {
+      await manager.configRegistry
+        .register(Path.join(__dirname, '../assets/config-paramranges-unknown-string.jsonld'));
+      manager.logger.error = jest.fn();
+
+      const run1 = await manager.instantiate('http://example.org/myconfig4');
+      expect(run1).toBeInstanceOf(Hello);
+      const value = run1._params[0].value;
+      expect(typeof value).toBe('string');
+      expect(value).toBe('456');
+    });
+  });
 });


### PR DESCRIPTION
Relevant issue: Components.js related issue in the Solid Community Server https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1182

# Purpose
The goal of these changes is to ensure that primitive constructor arguments preserve their data type when using `unknown` as argument type.

# Changes
I've updated the method `hasValueType` in ParameterPropertyHandlerRange to perform additional handling in case the type is a `ParameterRangeWildcard` (the type that is generated when using `unknown`).
- A private utility method `hasLiteralValueType` was added to encapsulate the handling of a literal.
- I've refactored the literal case to call this method
- The case when type is a `ParameterRangeWildcard`, now extracts the configured type of the argument and also calls `hasLiteralValueType` (when the found configured type is not string).

I've added testing for various cases of instantiations when using an unknown constructor argument in the file `instantiateFile-test`.

# Improvements
Possible improvements for this fix that can be performed by someone that is more familiar with the Components.js codebase:
- Because `hasValueType` has side-effects, it was not trivial to extract the logic that performs handling of the literals in an utility method. Hence I chose to throw an error when no handling was performed, allowing the calling code in `hasValueType` to continue processing when this occurs (instead of returning). This could be confusing, so maybe some refactoring is required.
- Testing: I've provided test cases in the form of integration tests, but ideally this functionality is also checked in `ParameterPropertyHandlerRange.test.ts` (but it was a bit daunting for me to make additions there).