### PR TITLE
Add support for overriding values

### DIFF
--- a/components/context.jsonld
+++ b/components/context.jsonld
@@ -77,6 +77,15 @@
     "undefined": {
       "@id": "oo:isUndefined"
     },
+    "Override": {
+      "@id": "oo:Override"
+    },
+    "overrideInstance": {
+      "@id": "oo:overrideInstance"
+    },
+    "overrideParameters": {
+      "@id": "oo:overrideParameters"
+    },
     "ParameterRange": {
       "@id": "oo:ParameterRange"
     },

--- a/lib/construction/IConfigConstructorPool.ts
+++ b/lib/construction/IConfigConstructorPool.ts
@@ -22,4 +22,9 @@ export interface IConfigConstructorPool<Instance> {
    */
   getInstanceRegistry: () => Record<string, Promise<Instance>>;
 
+  /**
+   * Resets any internal state to what it originally was.
+   * Used when new components are added inbetween 2 instantiations.
+   */
+  reset: () => void;
 }

--- a/lib/loading/ComponentsManagerBuilder.ts
+++ b/lib/loading/ComponentsManagerBuilder.ts
@@ -10,6 +10,7 @@ import { ConstructionStrategyCommonJs } from '../construction/strategy/Construct
 import type { IConstructionStrategy } from '../construction/strategy/IConstructionStrategy';
 import { ConfigPreprocessorComponent } from '../preprocess/ConfigPreprocessorComponent';
 import { ConfigPreprocessorComponentMapped } from '../preprocess/ConfigPreprocessorComponentMapped';
+import { ConfigPreprocessorOverride } from '../preprocess/ConfigPreprocessorOverride';
 import { ParameterHandler } from '../preprocess/ParameterHandler';
 import type { LogLevel } from '../util/LogLevel';
 import { ComponentRegistry } from './ComponentRegistry';
@@ -125,6 +126,11 @@ export class ComponentsManagerBuilder<Instance = any> {
     const configConstructorPool: IConfigConstructorPool<Instance> = new ConfigConstructorPool({
       objectLoader,
       configPreprocessors: [
+        new ConfigPreprocessorOverride({
+          objectLoader,
+          componentResources,
+          logger: this.logger,
+        }),
         new ConfigPreprocessorComponentMapped({
           objectLoader,
           runTypeConfigs,

--- a/lib/preprocess/ConfigPreprocessorComponent.ts
+++ b/lib/preprocess/ConfigPreprocessorComponent.ts
@@ -3,7 +3,7 @@ import type { Logger } from 'winston';
 import { IRIS_OWL } from '../rdf/Iris';
 import { ErrorResourcesContext } from '../util/ErrorResourcesContext';
 import { GenericsContext } from './GenericsContext';
-import type { IConfigPreprocessor } from './IConfigPreprocessor';
+import type { IConfigPreprocessorTransform, IConfigPreprocessor } from './IConfigPreprocessor';
 import type { ParameterHandler } from './ParameterHandler';
 
 /**
@@ -74,7 +74,8 @@ export class ConfigPreprocessorComponent implements IConfigPreprocessor<ICompone
     }
   }
 
-  public transform(config: Resource, handleResponse: IComponentConfigPreprocessorHandleResponse): Resource {
+  public transform(config: Resource, handleResponse: IComponentConfigPreprocessorHandleResponse):
+  IConfigPreprocessorTransform {
     // Inherit parameter values
     this.inheritParameterValues(config, handleResponse.component);
 
@@ -105,7 +106,7 @@ export class ConfigPreprocessorComponent implements IConfigPreprocessor<ICompone
     // Validate the input config
     this.validateConfig(config, handleResponse);
 
-    return configRaw;
+    return { rawConfig: configRaw, finishTransformation: true };
   }
 
   protected createGenericsContext(
@@ -300,6 +301,10 @@ export class ConfigPreprocessorComponent implements IConfigPreprocessor<ICompone
         }
       }
     }
+  }
+
+  public reset(): void {
+    // There is nothing to reset here
   }
 }
 

--- a/lib/preprocess/ConfigPreprocessorOverride.ts
+++ b/lib/preprocess/ConfigPreprocessorOverride.ts
@@ -1,0 +1,252 @@
+import type { Resource } from 'rdf-object';
+import type { RdfObjectLoader } from 'rdf-object/lib/RdfObjectLoader';
+import type { Logger } from 'winston';
+import { ErrorResourcesContext } from '../util/ErrorResourcesContext';
+import type { IConfigPreprocessor, IConfigPreprocessorTransform } from './IConfigPreprocessor';
+
+/**
+ * An {@link IConfigPreprocessor} that handles the overriding of parameters.
+ * Values in the given {@link Resource}s will be replaced if any overriding object is found,
+ * targeting this resource.
+ */
+export class ConfigPreprocessorOverride implements IConfigPreprocessor<Record<string, Resource>> {
+  public readonly objectLoader: RdfObjectLoader;
+  public readonly componentResources: Record<string, Resource>;
+  public readonly logger: Logger;
+
+  private overrides: Record<string, Record<string, Resource>> | undefined;
+
+  public constructor(options: IComponentConfigPreprocessorOverrideOptions) {
+    this.objectLoader = options.objectLoader;
+    this.componentResources = options.componentResources;
+    this.logger = options.logger;
+  }
+
+  /**
+   * Checks if there are any overrides targeting the given resource.
+   * @param config - Resource to find overrides for.
+   *
+   * @returns A key/value object with keys being the properties that have an override.
+   */
+  public canHandle(config: Resource): Record<string, Resource> | undefined {
+    if (!this.overrides) {
+      this.overrides = this.createOverrideObjects();
+    }
+    return this.overrides[config.value];
+  }
+
+  /**
+   * Override the resource with the stored values.
+   * @param config - The resource to override.
+   * @param handleResponse - Override values that were found for this resource.
+   */
+  public transform(config: Resource, handleResponse: Record<string, Resource>): IConfigPreprocessorTransform {
+    for (const id of Object.keys(config.properties)) {
+      const overrideValue = handleResponse[id];
+      if (overrideValue) {
+        config.properties[id] = [ overrideValue ];
+      }
+    }
+    return { rawConfig: config, finishTransformation: false };
+  }
+
+  /**
+   * Clear all cached overrides so they will be calculated again on the next call.
+   */
+  public reset(): void {
+    this.overrides = undefined;
+  }
+
+  /**
+   * Generates a cache of all overrides found in the object loader.
+   * Keys of the object are the identifiers of the resources that need to be modified,
+   * values are key/value maps listing all parameters with their new values.
+   */
+  public createOverrideObjects(): Record<string, Record<string, Resource>> {
+    const overrides = [ ...this.findOverrideTargets() ];
+    const chains = this.createOverrideChains(overrides);
+    this.validateChains(chains);
+    const overrideObjects: Record<string, Record<string, Resource>> = {};
+    for (const chain of chains) {
+      const { target, values } = this.chainToOverrideObject(chain);
+      if (Object.keys(values).length > 0) {
+        overrideObjects[target] = values;
+      }
+    }
+    return overrideObjects;
+  }
+
+  /**
+   * Finds all Override resources in the object loader and links them to their target resource.
+   */
+  protected * findOverrideTargets(): Iterable<{ override: Resource; target: Resource }> {
+    const overrideUri = this.objectLoader.contextResolved.expandTerm('oo:Override')!;
+    const overrideInstanceUri = this.objectLoader.contextResolved.expandTerm('oo:overrideInstance')!;
+    for (const [ id, resource ] of Object.entries(this.objectLoader.resources)) {
+      if (resource.isA(overrideUri) && resource.value !== overrideUri) {
+        const targets = resource.properties[overrideInstanceUri];
+        if (!targets || targets.length === 0) {
+          this.logger.warn(`Missing overrideInstance for ${id}. This Override will be ignored.`);
+          continue;
+        }
+        if (targets.length > 1) {
+          throw new ErrorResourcesContext(`Detected multiple overrideInstance targets for ${id}`, {
+            override: resource,
+          });
+        }
+        yield { override: resource, target: targets[0] };
+      }
+    }
+  }
+
+  /**
+   * Chains all Overrides together if they reference each other.
+   * E.g., if the input is a list of Overrides A -> B, B -> C, D -> E,
+   * the result wil be [[ A, B, C ], [ D, E ]].
+   *
+   * @param overrides - All Overrides that have to be combined.
+   */
+  protected createOverrideChains(overrides: { override: Resource; target: Resource }[]): Resource[][] {
+    // Start by creating small chains: from each override to its immediate target
+    const overrideChains = Object.fromEntries(
+      overrides.map(({ override, target }): [ string, Resource[]] =>
+        [ override.value, [ override, target ]]),
+    );
+
+    // Then keep combining those smaller chains into bigger chains until they are complete.
+    // If there is an override cycle (A -> B -> ... -> A) it will delete itself from the list of chains here.
+    let change = true;
+    while (change) {
+      change = false;
+      for (const [ id, chain ] of Object.entries(overrideChains)) {
+        let next = chain[chain.length - 1];
+        // If the next part of the chain is found in `overrideChains` we can merge them and remove the tail entry
+        while (overrideChains[next.value]) {
+          change = true;
+          const nextChain = overrideChains[next.value];
+          // First element of nextChain will be equal to last element of this chain
+          overrideChains[id].push(...nextChain.slice(1));
+          // In case of a cycle there will be a point where next equals the first element,
+          // at which point it will delete itself.
+          delete overrideChains[next.value];
+          next = chain[chain.length - 1];
+        }
+        // Reset the loop since we are modifying the object we are iterating over
+        if (change) {
+          break;
+        }
+      }
+    }
+
+    return Object.values(overrideChains);
+  }
+
+  /**
+   * Throws an error in case there are 2 chains targeting the same resource.
+   * @param chains - The override chains to check.
+   */
+  protected validateChains(chains: Resource[][]): void {
+    const targets = chains.map((chain): string => chain[chain.length - 1].value);
+    for (let i = 0; i < targets.length; ++i) {
+      const duplicateIdx = targets.findIndex((target, idx): boolean => idx > i && target === targets[i]);
+      if (duplicateIdx > 0) {
+        const target = chains[i][chains[i].length - 1];
+        const duplicate1 = chains[i][chains[i].length - 2];
+        const duplicate2 = chains[duplicateIdx][chains[duplicateIdx].length - 2];
+        throw new ErrorResourcesContext(`Found multiple Overrides targeting ${targets[i]}`, {
+          target,
+          overrides: [ duplicate1, duplicate2 ],
+        });
+      }
+    }
+  }
+
+  /**
+   * Merges all Overrides in a chain to create a single override object
+   * containing replacement values for all relevant parameters of the final entry in the chain.
+   *
+   * @param chain - The chain of Overrides, with a normal resource as the last entry in the array.
+   */
+  protected chainToOverrideObject(chain: Resource[]): { target: string; values: Record<string, Resource> } {
+    const { target, type } = this.getChainTarget(chain);
+
+    // Apply all overrides sequentially, starting from the one closest to the target.
+    // This ensures the most recent override has priority.
+    const parameters = this.componentResources[type.value].properties.parameters;
+    const mergedOverride: Record<string, Resource> = {};
+    for (let i = chain.length - 2; i >= 0; --i) {
+      const filteredObject = this.filterOverrideObject(chain[i], target, parameters);
+      Object.assign(mergedOverride, filteredObject);
+    }
+    return { target: target.value, values: mergedOverride };
+  }
+
+  /**
+   * Finds the final target and its type in an override chain.
+   * @param chain - The chain to find the target of.
+   */
+  protected getChainTarget(chain: Resource[]): { target: Resource; type: Resource } {
+    const rdfTypeUri = this.objectLoader.contextResolved.expandTerm('rdf:type')!;
+    const target = chain[chain.length - 1];
+    const types = target.properties[rdfTypeUri];
+    if (!types || types.length === 0) {
+      throw new ErrorResourcesContext(`Missing type for override target ${target.value} of Override ${chain[chain.length - 2].value}`, {
+        target,
+        override: chain[chain.length - 2],
+      });
+    }
+    if (types.length > 1) {
+      throw new ErrorResourcesContext(`Found multiple types for override target ${target.value} of Override ${chain[chain.length - 2].value}`, {
+        target,
+        override: chain[chain.length - 2],
+      });
+    }
+    return { target, type: types[0] };
+  }
+
+  /**
+   * Extracts all relevant parameters of an Override with their corresponding new value.
+   * @param override - The Override to apply.
+   * @param target - The target resource to apply the Override to.
+   * @param parameters - The parameters that are relevant for the target.
+   */
+  protected filterOverrideObject(override: Resource, target: Resource, parameters: Resource[]):
+  Record<string, Resource> {
+    const overrideParametersUri = this.objectLoader.contextResolved.expandTerm('oo:overrideParameters')!;
+    const overrideObjects = override.properties[overrideParametersUri];
+    if (!overrideObjects || overrideObjects.length === 0) {
+      this.logger.warn(`No overrideParameters found for ${override.value}.`);
+      return {};
+    }
+    if (overrideObjects.length > 1) {
+      throw new ErrorResourcesContext(`Detected multiple values for overrideParameters in Override ${override.value}`, {
+        override,
+      });
+    }
+    const overrideObject = overrideObjects[0];
+
+    // Only keep the parameters that are known to the type of the target object
+    const filteredObject: Record<string, Resource> = {};
+    for (const parameter of parameters) {
+      const overrideValues = overrideObject.properties[parameter.value];
+      if (!overrideValues || overrideValues.length === 0) {
+        continue;
+      }
+      if (overrideValues.length > 1) {
+        throw new ErrorResourcesContext(`Detected multiple values for override parameter ${parameter.value} in Override ${override.value}. RDF lists should be used for defining multiple values.`, {
+          arguments: overrideValues,
+          target,
+          override,
+        });
+      }
+      filteredObject[parameter.value] = overrideValues[0];
+    }
+    return filteredObject;
+  }
+}
+
+export interface IComponentConfigPreprocessorOverrideOptions {
+  objectLoader: RdfObjectLoader;
+  componentResources: Record<string, Resource>;
+  logger: Logger;
+}

--- a/lib/preprocess/IConfigPreprocessor.ts
+++ b/lib/preprocess/IConfigPreprocessor.ts
@@ -1,5 +1,16 @@
 import type { Resource } from 'rdf-object';
 
+export interface IConfigPreprocessorTransform {
+  /**
+   * If the result is final or other preprocessors are allowed to continue.
+   */
+  finishTransformation: boolean;
+  /**
+   * The result of the transform.
+   */
+  rawConfig: Resource;
+}
+
 /**
  * Transforms an enhanced config of a certain form into a raw config
  * so that it can be instantiated by {@link ConfigConstructor}.
@@ -15,5 +26,10 @@ export interface IConfigPreprocessor<HR> {
    * @param config Config to transform.
    * @param handleResponse Return value of the {#canHandle}.
    */
-  transform: (config: Resource, handleResponse: HR) => Resource;
+  transform: (config: Resource, handleResponse: HR) => IConfigPreprocessorTransform;
+  /**
+   * Resets any internal state to what it originally was.
+   * Used when new components are added inbetween 2 instantiations.
+   */
+  reset: () => void;
 }

--- a/test/assets/config-override-additional.jsonld
+++ b/test/assets/config-override-additional.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "@vocab": "https://linkedsoftwaredependencies.org/vocabularies/object-oriented#",
+    "ex": "http://example.org/",
+    "hello": "http://example.org/hello/"
+  },
+  "@graph": [
+    {
+      "@id": "ex:myObjectOverrideAddition",
+      "@type": "Override",
+      "overrideInstance": { "@id": "ex:myObjectOverrideFinal" },
+      "overrideParameters": {
+        "hello:hello": "ADDITIONAL WORLD"
+      }
+    }
+  ]
+}

--- a/test/assets/config-override-reverse.jsonld
+++ b/test/assets/config-override-reverse.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://linkedsoftwaredependencies.org/vocabularies/object-oriented#",
+    "ex": "http://example.org/",
+    "hello": "http://example.org/hello/"
+  },
+  "@graph": [
+    {
+      "@id": "ex:myHelloWorldWithOverride",
+      "@type": "ex:HelloWorldModule#SayHelloComponent",
+      "hello:hello": "WORLD",
+      "hello:say": "HI"
+    },
+    {
+      "@id": "ex:myObjectOverrideFinal",
+      "@type": "Override",
+      "overrideInstance": { "@id": "ex:myObjectOverride" },
+      "overrideParameters": {
+        "hello:hello": "EVEN BETTER WORLD"
+      }
+    },
+    {
+      "@id": "ex:myObjectOverride",
+      "@type": "Override",
+      "overrideInstance": { "@id": "ex:myHelloWorldWithOverride" },
+      "overrideParameters": {
+        "hello:hello": "BETTER WORLD"
+      }
+    }
+  ]
+}

--- a/test/assets/config-override.jsonld
+++ b/test/assets/config-override.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "https://linkedsoftwaredependencies.org/vocabularies/object-oriented#",
+    "ex": "http://example.org/",
+    "hello": "http://example.org/hello/"
+  },
+  "@graph": [
+    {
+      "@id": "ex:myHelloWorldWithOverride",
+      "@type": "ex:HelloWorldModule#SayHelloComponent",
+      "hello:hello": "WORLD",
+      "hello:say": "HI"
+    },
+    {
+      "@id": "ex:myObjectOverride",
+      "@type": "Override",
+      "overrideInstance": { "@id": "ex:myHelloWorldWithOverride" },
+      "overrideParameters": {
+        "hello:hello": "BETTER WORLD"
+      }
+    },
+    {
+      "@id": "ex:myObjectOverrideFinal",
+      "@type": "Override",
+      "overrideInstance": { "@id": "ex:myObjectOverride" },
+      "overrideParameters": {
+        "hello:hello": "EVEN BETTER WORLD"
+      }
+    }
+  ]
+}

--- a/test/unit/construction/ConfigConstructorPool-test.ts
+++ b/test/unit/construction/ConfigConstructorPool-test.ts
@@ -313,6 +313,19 @@ describe('ConfigConstructorPool', () => {
         ]);
         expect(instance1).toBe(instance2);
       });
+
+      it('should return different instances by equal id after reset', async() => {
+        const instance1 = await pool.instantiate(objectLoader.createCompactedResource({
+          '@id': 'ex:myComponentInstance1',
+          types: 'ex:Component',
+        }), creationSettings);
+        pool.reset();
+        const instance2 = await pool.instantiate(objectLoader.createCompactedResource({
+          '@id': 'ex:myComponentInstance1',
+          types: 'ex:Component',
+        }), creationSettings);
+        expect(instance1).not.toBe(instance2);
+      });
     });
   });
 

--- a/test/unit/loading/ComponentsManagerBuilder-test.ts
+++ b/test/unit/loading/ComponentsManagerBuilder-test.ts
@@ -9,6 +9,7 @@ import { ComponentsManagerBuilder } from '../../../lib/loading/ComponentsManager
 import { ConfigRegistry } from '../../../lib/loading/ConfigRegistry';
 import { ConfigPreprocessorComponent } from '../../../lib/preprocess/ConfigPreprocessorComponent';
 import { ConfigPreprocessorComponentMapped } from '../../../lib/preprocess/ConfigPreprocessorComponentMapped';
+import { ConfigPreprocessorOverride } from '../../../lib/preprocess/ConfigPreprocessorOverride';
 
 const mainModulePath = __dirname;
 jest.mock('winston', () => ({
@@ -69,9 +70,10 @@ describe('ComponentsManagerBuilder', () => {
     expect(mgr.dumpErrorState).toBe(true);
     expect(mgr.configConstructorPool).toBeInstanceOf(ConfigConstructorPool);
     expect((<any> mgr.configConstructorPool).constructionStrategy).toBeInstanceOf(ConstructionStrategyCommonJs);
-    expect((<any> mgr.configConstructorPool).configPreprocessors.length).toBe(2);
-    expect((<any> mgr.configConstructorPool).configPreprocessors[0]).toBeInstanceOf(ConfigPreprocessorComponentMapped);
-    expect((<any> mgr.configConstructorPool).configPreprocessors[1]).toBeInstanceOf(ConfigPreprocessorComponent);
+    expect((<any> mgr.configConstructorPool).configPreprocessors.length).toBe(3);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[0]).toBeInstanceOf(ConfigPreprocessorOverride);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[1]).toBeInstanceOf(ConfigPreprocessorComponentMapped);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[2]).toBeInstanceOf(ConfigPreprocessorComponent);
     expect(mgr.logger).toBeTruthy();
     expect(createLogger).toHaveBeenCalledWith({
       level: 'warn',
@@ -95,9 +97,10 @@ describe('ComponentsManagerBuilder', () => {
     expect(mgr.dumpErrorState).toBe(true);
     expect(mgr.configConstructorPool).toBeInstanceOf(ConfigConstructorPool);
     expect((<any> mgr.configConstructorPool).constructionStrategy).toBeInstanceOf(ConstructionStrategyCommonJs);
-    expect((<any> mgr.configConstructorPool).configPreprocessors.length).toBe(2);
-    expect((<any> mgr.configConstructorPool).configPreprocessors[0]).toBeInstanceOf(ConfigPreprocessorComponentMapped);
-    expect((<any> mgr.configConstructorPool).configPreprocessors[1]).toBeInstanceOf(ConfigPreprocessorComponent);
+    expect((<any> mgr.configConstructorPool).configPreprocessors.length).toBe(3);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[0]).toBeInstanceOf(ConfigPreprocessorOverride);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[1]).toBeInstanceOf(ConfigPreprocessorComponentMapped);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[2]).toBeInstanceOf(ConfigPreprocessorComponent);
     expect(mgr.logger).toBeTruthy();
     expect(createLogger).toHaveBeenCalledWith({
       level: 'warn',
@@ -127,9 +130,10 @@ describe('ComponentsManagerBuilder', () => {
     expect(mgr.dumpErrorState).toBe(true);
     expect(mgr.configConstructorPool).toBeInstanceOf(ConfigConstructorPool);
     expect((<any> mgr.configConstructorPool).constructionStrategy).toBeInstanceOf(ConstructionStrategyCommonJs);
-    expect((<any> mgr.configConstructorPool).configPreprocessors.length).toBe(2);
-    expect((<any> mgr.configConstructorPool).configPreprocessors[0]).toBeInstanceOf(ConfigPreprocessorComponentMapped);
-    expect((<any> mgr.configConstructorPool).configPreprocessors[1]).toBeInstanceOf(ConfigPreprocessorComponent);
+    expect((<any> mgr.configConstructorPool).configPreprocessors.length).toBe(3);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[0]).toBeInstanceOf(ConfigPreprocessorOverride);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[1]).toBeInstanceOf(ConfigPreprocessorComponentMapped);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[2]).toBeInstanceOf(ConfigPreprocessorComponent);
     expect(mgr.logger).toBeTruthy();
     expect(createLogger).toHaveBeenCalledWith({
       level: 'warn',
@@ -157,9 +161,10 @@ describe('ComponentsManagerBuilder', () => {
     expect(mgr.dumpErrorState).toBe(true);
     expect(mgr.configConstructorPool).toBeInstanceOf(ConfigConstructorPool);
     expect((<any> mgr.configConstructorPool).constructionStrategy).toBeInstanceOf(ConstructionStrategyCommonJs);
-    expect((<any> mgr.configConstructorPool).configPreprocessors.length).toBe(2);
-    expect((<any> mgr.configConstructorPool).configPreprocessors[0]).toBeInstanceOf(ConfigPreprocessorComponentMapped);
-    expect((<any> mgr.configConstructorPool).configPreprocessors[1]).toBeInstanceOf(ConfigPreprocessorComponent);
+    expect((<any> mgr.configConstructorPool).configPreprocessors.length).toBe(3);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[0]).toBeInstanceOf(ConfigPreprocessorOverride);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[1]).toBeInstanceOf(ConfigPreprocessorComponentMapped);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[2]).toBeInstanceOf(ConfigPreprocessorComponent);
     expect(mgr.logger).toBeTruthy();
     expect(createLogger).toHaveBeenCalledWith({
       level: 'warn',
@@ -183,9 +188,10 @@ describe('ComponentsManagerBuilder', () => {
     expect(mgr.dumpErrorState).toBe(true);
     expect(mgr.configConstructorPool).toBeInstanceOf(ConfigConstructorPool);
     expect((<any> mgr.configConstructorPool).constructionStrategy).toBe(constructionStrategy);
-    expect((<any> mgr.configConstructorPool).configPreprocessors.length).toBe(2);
-    expect((<any> mgr.configConstructorPool).configPreprocessors[0]).toBeInstanceOf(ConfigPreprocessorComponentMapped);
-    expect((<any> mgr.configConstructorPool).configPreprocessors[1]).toBeInstanceOf(ConfigPreprocessorComponent);
+    expect((<any> mgr.configConstructorPool).configPreprocessors.length).toBe(3);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[0]).toBeInstanceOf(ConfigPreprocessorOverride);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[1]).toBeInstanceOf(ConfigPreprocessorComponentMapped);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[2]).toBeInstanceOf(ConfigPreprocessorComponent);
     expect(mgr.logger).toBeTruthy();
     expect(createLogger).toHaveBeenCalledWith({
       level: 'warn',
@@ -208,9 +214,10 @@ describe('ComponentsManagerBuilder', () => {
     expect(mgr.dumpErrorState).toBe(true);
     expect(mgr.configConstructorPool).toBeInstanceOf(ConfigConstructorPool);
     expect((<any> mgr.configConstructorPool).constructionStrategy).toBeInstanceOf(ConstructionStrategyCommonJs);
-    expect((<any> mgr.configConstructorPool).configPreprocessors.length).toBe(2);
-    expect((<any> mgr.configConstructorPool).configPreprocessors[0]).toBeInstanceOf(ConfigPreprocessorComponentMapped);
-    expect((<any> mgr.configConstructorPool).configPreprocessors[1]).toBeInstanceOf(ConfigPreprocessorComponent);
+    expect((<any> mgr.configConstructorPool).configPreprocessors.length).toBe(3);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[0]).toBeInstanceOf(ConfigPreprocessorOverride);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[1]).toBeInstanceOf(ConfigPreprocessorComponentMapped);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[2]).toBeInstanceOf(ConfigPreprocessorComponent);
     expect(mgr.logger).toBeTruthy();
     expect(createLogger).toHaveBeenCalledWith({
       level: 'warn',
@@ -233,9 +240,10 @@ describe('ComponentsManagerBuilder', () => {
     expect(mgr.dumpErrorState).toBe(false);
     expect(mgr.configConstructorPool).toBeInstanceOf(ConfigConstructorPool);
     expect((<any> mgr.configConstructorPool).constructionStrategy).toBeInstanceOf(ConstructionStrategyCommonJs);
-    expect((<any> mgr.configConstructorPool).configPreprocessors.length).toBe(2);
-    expect((<any> mgr.configConstructorPool).configPreprocessors[0]).toBeInstanceOf(ConfigPreprocessorComponentMapped);
-    expect((<any> mgr.configConstructorPool).configPreprocessors[1]).toBeInstanceOf(ConfigPreprocessorComponent);
+    expect((<any> mgr.configConstructorPool).configPreprocessors.length).toBe(3);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[0]).toBeInstanceOf(ConfigPreprocessorOverride);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[1]).toBeInstanceOf(ConfigPreprocessorComponentMapped);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[2]).toBeInstanceOf(ConfigPreprocessorComponent);
     expect(mgr.logger).toBeTruthy();
     expect(createLogger).toHaveBeenCalledWith({
       level: 'warn',
@@ -258,9 +266,10 @@ describe('ComponentsManagerBuilder', () => {
     expect(mgr.dumpErrorState).toBe(true);
     expect(mgr.configConstructorPool).toBeInstanceOf(ConfigConstructorPool);
     expect((<any> mgr.configConstructorPool).constructionStrategy).toBeInstanceOf(ConstructionStrategyCommonJs);
-    expect((<any> mgr.configConstructorPool).configPreprocessors.length).toBe(2);
-    expect((<any> mgr.configConstructorPool).configPreprocessors[0]).toBeInstanceOf(ConfigPreprocessorComponentMapped);
-    expect((<any> mgr.configConstructorPool).configPreprocessors[1]).toBeInstanceOf(ConfigPreprocessorComponent);
+    expect((<any> mgr.configConstructorPool).configPreprocessors.length).toBe(3);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[0]).toBeInstanceOf(ConfigPreprocessorOverride);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[1]).toBeInstanceOf(ConfigPreprocessorComponentMapped);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[2]).toBeInstanceOf(ConfigPreprocessorComponent);
     expect(mgr.logger).toBeTruthy();
     expect(createLogger).toBeCalledTimes(1);
     expect(createLogger).toHaveBeenCalledWith({
@@ -291,9 +300,10 @@ describe('ComponentsManagerBuilder', () => {
     expect(mgr.dumpErrorState).toBe(true);
     expect(mgr.configConstructorPool).toBeInstanceOf(ConfigConstructorPool);
     expect((<any> mgr.configConstructorPool).constructionStrategy).toBeInstanceOf(ConstructionStrategyCommonJs);
-    expect((<any> mgr.configConstructorPool).configPreprocessors.length).toBe(2);
-    expect((<any> mgr.configConstructorPool).configPreprocessors[0]).toBeInstanceOf(ConfigPreprocessorComponentMapped);
-    expect((<any> mgr.configConstructorPool).configPreprocessors[1]).toBeInstanceOf(ConfigPreprocessorComponent);
+    expect((<any> mgr.configConstructorPool).configPreprocessors.length).toBe(3);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[0]).toBeInstanceOf(ConfigPreprocessorOverride);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[1]).toBeInstanceOf(ConfigPreprocessorComponentMapped);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[2]).toBeInstanceOf(ConfigPreprocessorComponent);
     expect(mgr.logger).toBeTruthy();
     expect(createLogger).toBeCalledTimes(1);
     expect(createLogger).toHaveBeenCalledWith({
@@ -317,9 +327,10 @@ describe('ComponentsManagerBuilder', () => {
     expect(mgr.dumpErrorState).toBe(true);
     expect(mgr.configConstructorPool).toBeInstanceOf(ConfigConstructorPool);
     expect((<any> mgr.configConstructorPool).constructionStrategy).toBeInstanceOf(ConstructionStrategyCommonJs);
-    expect((<any> mgr.configConstructorPool).configPreprocessors.length).toBe(2);
-    expect((<any> mgr.configConstructorPool).configPreprocessors[0]).toBeInstanceOf(ConfigPreprocessorComponentMapped);
-    expect((<any> mgr.configConstructorPool).configPreprocessors[1]).toBeInstanceOf(ConfigPreprocessorComponent);
+    expect((<any> mgr.configConstructorPool).configPreprocessors.length).toBe(3);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[0]).toBeInstanceOf(ConfigPreprocessorOverride);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[1]).toBeInstanceOf(ConfigPreprocessorComponentMapped);
+    expect((<any> mgr.configConstructorPool).configPreprocessors[2]).toBeInstanceOf(ConfigPreprocessorComponent);
     expect(mgr.logger).toBeTruthy();
     expect(createLogger).toBeCalledTimes(1);
     expect(createLogger).toHaveBeenCalledWith({

--- a/test/unit/preprocess/ConfigPreprocessorComponent-test.ts
+++ b/test/unit/preprocess/ConfigPreprocessorComponent-test.ts
@@ -440,8 +440,9 @@ describe('ConfigPreprocessorComponent', () => {
   describe('transform', () => {
     function expectTransformOutput(config: Resource, expectedResource: Resource) {
       const hr = <IComponentConfigPreprocessorHandleResponse> preprocessor.canHandle(config);
-      const ret = preprocessor.transform(config, hr);
-      expect(expectedResource.toQuads()).toBeRdfIsomorphic(ret.toQuads());
+      const { finishTransformation, rawConfig } = preprocessor.transform(config, hr);
+      expect(expectedResource.toQuads()).toBeRdfIsomorphic(rawConfig.toQuads());
+      expect(finishTransformation).toBe(true);
     }
 
     it('should handle no parameters', () => {

--- a/test/unit/preprocess/ConfigPreprocessorOverride-test.ts
+++ b/test/unit/preprocess/ConfigPreprocessorOverride-test.ts
@@ -1,0 +1,343 @@
+import 'jest-rdf';
+import * as fs from 'fs';
+import { DataFactory } from 'rdf-data-factory';
+import type { Resource } from 'rdf-object';
+import { RdfObjectLoader } from 'rdf-object';
+import type { Logger } from 'winston';
+import { ConfigPreprocessorOverride } from '../../../lib/preprocess/ConfigPreprocessorOverride';
+
+const DF = new DataFactory();
+
+describe('ConfigPreprocessorOverride', () => {
+  let objectLoader: RdfObjectLoader;
+  let componentResources: Record<string, Resource>;
+  let logger: Logger;
+  let preprocessor: ConfigPreprocessorOverride;
+  let overrideParameters: string;
+
+  beforeEach(async() => {
+    objectLoader = new RdfObjectLoader({
+      context: JSON.parse(fs.readFileSync(`${__dirname}/../../../components/context.jsonld`, 'utf8')),
+    });
+    await objectLoader.context;
+
+    overrideParameters = objectLoader.contextResolved.expandTerm('oo:overrideParameters')!;
+
+    componentResources = {
+      'ex:Component': objectLoader.createCompactedResource({
+        '@id': 'ex:Component',
+        module: 'ex:Module',
+        parameters: [
+          { '@id': 'ex:param1' },
+          { '@id': 'ex:param2' },
+        ],
+      }),
+    };
+    logger = <any> {
+      warn: jest.fn(),
+    };
+    preprocessor = new ConfigPreprocessorOverride({
+      objectLoader,
+      componentResources,
+      logger,
+    });
+  });
+
+  it('should not handle resources with no override', () => {
+    const config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+      types: 'ex:Component',
+    });
+    expect(preprocessor.canHandle(config)).toBeUndefined();
+  });
+
+  it('should handle resources with an override', () => {
+    const config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+      types: 'ex:Component',
+    });
+    const overrideInstance = objectLoader.createCompactedResource({
+      '@id': 'ex:myOverride',
+      types: 'oo:Override',
+      overrideInstance: 'ex:myComponentInstance',
+      overrideParameters: {
+        'ex:param1': '"hello"',
+      },
+    });
+    const overrideProperties = overrideInstance.properties[overrideParameters][0].properties;
+    const override = preprocessor.canHandle(config);
+    expect(override).not.toBeUndefined();
+    expect(Object.keys(override!).length).toBe(1);
+    expect(override!['ex:param1']).toBe(overrideProperties['ex:param1'][0]);
+  });
+
+  it('should only override the relevant parameters of a resource', () => {
+    const config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+      types: 'ex:Component',
+      'ex:param1': '"value1"',
+      'ex:param2': '"value2"',
+    });
+    const overrideInstance = objectLoader.createCompactedResource({
+      '@id': 'ex:myOverride',
+      types: 'oo:Override',
+      overrideInstance: 'ex:myComponentInstance',
+      overrideParameters: {
+        'ex:param1': '"updatedValue"',
+      },
+    });
+    const overrideProperties = overrideInstance.properties[overrideParameters][0].properties;
+    const override = preprocessor.canHandle(config)!;
+    const { rawConfig, finishTransformation } = preprocessor.transform(config, override);
+    expect(finishTransformation).toBe(false);
+    expect(rawConfig).toBe(config);
+    expect(rawConfig.properties['ex:param1'][0]).toBe(overrideProperties['ex:param1'][0]);
+    expect(rawConfig.properties['ex:param1'][0].value).toBe('updatedValue');
+    expect(rawConfig.properties['ex:param2'][0].value).toBe('value2');
+  });
+
+  it('can chain overrides', () => {
+    const config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+      types: 'ex:Component',
+      'ex:param1': '"value1"',
+      'ex:param2': '"value2"',
+    });
+    const overrideInstance1 = objectLoader.createCompactedResource({
+      '@id': 'ex:myOverride1',
+      types: 'oo:Override',
+      overrideInstance: 'ex:myComponentInstance',
+      overrideParameters: {
+        'ex:param1': '"value1-1"',
+        'ex:param2': '"value2-1"',
+      },
+    });
+    const overrideInstance2 = objectLoader.createCompactedResource({
+      '@id': 'ex:myOverride2',
+      types: 'oo:Override',
+      overrideInstance: 'ex:myOverride1',
+      overrideParameters: {
+        'ex:param1': '"value1-2"',
+      },
+    });
+    const override1Properties = overrideInstance1.properties[overrideParameters][0].properties;
+    const override2Properties = overrideInstance2.properties[overrideParameters][0].properties;
+    const override = preprocessor.canHandle(config)!;
+    const { rawConfig, finishTransformation } = preprocessor.transform(config, override);
+    expect(finishTransformation).toBe(false);
+    expect(rawConfig).toBe(config);
+    expect(rawConfig.properties['ex:param1'][0]).toBe(override2Properties['ex:param1'][0]);
+    expect(rawConfig.properties['ex:param1'][0].value).toBe('value1-2');
+    expect(rawConfig.properties['ex:param2'][0]).toBe(override1Properties['ex:param2'][0]);
+    expect(rawConfig.properties['ex:param2'][0].value).toBe('value2-1');
+  });
+
+  it('caches the overrides', () => {
+    const config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+      types: 'ex:Component',
+    });
+    const overrideInstance1 = objectLoader.createCompactedResource({
+      '@id': 'ex:myOverride1',
+      types: 'oo:Override',
+      overrideInstance: 'ex:myComponentInstance',
+      overrideParameters: {
+        'ex:param1': '"value1-1"',
+      },
+    });
+    const override1Properties = overrideInstance1.properties[overrideParameters][0].properties;
+    let override = preprocessor.canHandle(config);
+    expect(override).not.toBeUndefined();
+    expect(Object.keys(override!).length).toBe(1);
+    expect(override!['ex:param1']).toBe(override1Properties['ex:param1'][0]);
+
+    objectLoader.createCompactedResource({
+      '@id': 'ex:myOverride2',
+      types: 'oo:Override',
+      overrideInstance: 'ex:myOverride1',
+      overrideParameters: {
+        'ex:param1': '"value1-2"',
+      },
+    });
+    // `ex:myOverride2` will not be applied due to cache
+    override = preprocessor.canHandle(config);
+    expect(override).not.toBeUndefined();
+    expect(Object.keys(override!).length).toBe(1);
+    expect(override!['ex:param1']).toBe(override1Properties['ex:param1'][0]);
+    expect(override!['ex:param1'].value).toBe('value1-1');
+  });
+
+  it('can reset the override cache', () => {
+    const config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+      types: 'ex:Component',
+    });
+    const overrideInstance1 = objectLoader.createCompactedResource({
+      '@id': 'ex:myOverride1',
+      types: 'oo:Override',
+      overrideInstance: 'ex:myComponentInstance',
+      overrideParameters: {
+        'ex:param1': '"value1-1"',
+      },
+    });
+    const override1Properties = overrideInstance1.properties[overrideParameters][0].properties;
+    let override = preprocessor.canHandle(config);
+    expect(override).not.toBeUndefined();
+    expect(Object.keys(override!).length).toBe(1);
+    expect(override!['ex:param1']).toBe(override1Properties['ex:param1'][0]);
+
+    const overrideInstance2 = objectLoader.createCompactedResource({
+      '@id': 'ex:myOverride2',
+      types: 'oo:Override',
+      overrideInstance: 'ex:myOverride1',
+      overrideParameters: {
+        'ex:param1': '"value1-2"',
+      },
+    });
+    const override2Properties = overrideInstance2.properties[overrideParameters][0].properties;
+    // `ex:myOverride2` is applied if we reset
+    preprocessor.reset();
+    override = preprocessor.canHandle(config);
+    expect(override).not.toBeUndefined();
+    expect(Object.keys(override!).length).toBe(1);
+    expect(override!['ex:param1']).toBe(override2Properties['ex:param1'][0]);
+    expect(override!['ex:param1'].value).toBe('value1-2');
+  });
+
+  it('logs a warning if if an Override has no target', () => {
+    const config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+      types: 'ex:Component',
+    });
+    objectLoader.createCompactedResource({
+      '@id': 'ex:myOverride',
+      types: 'oo:Override',
+      overrideParameters: {
+        'ex:param1': '"hello"',
+      },
+    });
+    expect(preprocessor.canHandle(config)).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenLastCalledWith(`Missing overrideInstance for ex:myOverride. This Override will be ignored.`);
+  });
+
+  it('logs a warning if there is an Override with no specified parameters', () => {
+    const config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+      types: 'ex:Component',
+    });
+    objectLoader.createCompactedResource({
+      '@id': 'ex:myOverride',
+      types: 'oo:Override',
+      overrideInstance: 'ex:myComponentInstance',
+    });
+    preprocessor.canHandle(config);
+    expect(preprocessor.canHandle(config)).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenLastCalledWith(`No overrideParameters found for ex:myOverride.`);
+  });
+
+  it('errors if an Override has multiple targets', () => {
+    const config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+      types: 'ex:Component',
+    });
+    objectLoader.createCompactedResource({
+      '@id': 'ex:myOverride',
+      types: 'oo:Override',
+      overrideInstance: [ 'ex:myComponentInstance', 'ex:myComponentInstance2' ],
+      overrideParameters: {
+        'ex:param1': '"hello"',
+      },
+    });
+    expect(() => preprocessor.canHandle(config)).toThrow(`Detected multiple overrideInstance targets for ex:myOverride`);
+  });
+
+  it('errors if a resource has multiple Overrides targeting it', () => {
+    const config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+      types: 'ex:Component',
+    });
+    objectLoader.createCompactedResource({
+      '@id': 'ex:myOverride1',
+      types: 'oo:Override',
+      overrideInstance: 'ex:myComponentInstance',
+      overrideParameters: {
+        'ex:param1': '"hello"',
+      },
+    });
+    objectLoader.createCompactedResource({
+      '@id': 'ex:myOverride2',
+      types: 'oo:Override',
+      overrideInstance: 'ex:myComponentInstance',
+      overrideParameters: {
+        'ex:param1': '"hello"',
+      },
+    });
+    expect(() => preprocessor.canHandle(config)).toThrow(`Found multiple Overrides targeting ex:myComponentInstance`);
+  });
+
+  it('errors if an override target has no type', () => {
+    const config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+    });
+    objectLoader.createCompactedResource({
+      '@id': 'ex:myOverride',
+      types: 'oo:Override',
+      overrideInstance: 'ex:myComponentInstance',
+      overrideParameters: {
+        'ex:param1': '"hello"',
+      },
+    });
+    expect(() => preprocessor.canHandle(config)).toThrow(`Missing type for override target ex:myComponentInstance of Override ex:myOverride`);
+  });
+
+  it('errors if an override target has multiple types', () => {
+    const config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+      types: [ 'ex:Component', 'ex:ExtraType' ],
+    });
+    objectLoader.createCompactedResource({
+      '@id': 'ex:myOverride',
+      types: 'oo:Override',
+      overrideInstance: 'ex:myComponentInstance',
+      overrideParameters: {
+        'ex:param1': '"hello"',
+      },
+    });
+    expect(() => preprocessor.canHandle(config)).toThrow(`Found multiple types for override target ex:myComponentInstance of Override ex:myOverride`);
+  });
+
+  it('errors if an Override has multiple overrideParameters objects', () => {
+    const config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+      types: 'ex:Component',
+    });
+    objectLoader.createCompactedResource({
+      '@id': 'ex:myOverride',
+      types: 'oo:Override',
+      overrideInstance: 'ex:myComponentInstance',
+      overrideParameters: [
+        { 'ex:param1': '"hello"' },
+        { 'ex:param1': '"bye"' },
+      ],
+    });
+    expect(() => preprocessor.canHandle(config)).toThrow(`Detected multiple values for overrideParameters in Override ex:myOverride`);
+  });
+
+  it('errors if an overrideParameters entry has multiple values', () => {
+    const config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+      types: 'ex:Component',
+    });
+    objectLoader.createCompactedResource({
+      '@id': 'ex:myOverride',
+      types: 'oo:Override',
+      overrideInstance: 'ex:myComponentInstance',
+      overrideParameters: {
+        'ex:param1': [ '"hello"', '"bye"' ],
+      },
+    });
+    expect(() => preprocessor.canHandle(config)).toThrow(`Detected multiple values for override parameter ex:param1 in Override ex:myOverride. RDF lists should be used for defining multiple values.`);
+  });
+});


### PR DESCRIPTION
Closes https://github.com/LinkedSoftwareDependencies/Components.js/issues/66
Does exactly what I want to do in the 2nd part of https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1348.

This is my suggestion on how to allow values to be replaced in Components.js. Every time the value for a parameter gets requested, now it first checks if there is a potential override value. This does partially break the RDF interpretation of these objects, so suggestions there are welcome if it somehow can be improved, but changing the identifiers would make this feature useless.

I wanted to make this a `ParameterPropertyHandler`, but that does not allow the recursive call to the same function again so had to put it in there.

Added the `override` predicate to the `oo` ontology just so I had a predicate, but this can be moved/renamed to wherever it fits best.

If accepted, documentation about this should probably also be added somewhere but not sure where.

As an aside, I noticed all the integration test modules still use a 4.0.0 context.