### PR TITLE
Ignore duplicate types when overriding components

### DIFF
--- a/lib/preprocess/ConfigPreprocessorComponent.ts
+++ b/lib/preprocess/ConfigPreprocessorComponent.ts
@@ -1,6 +1,7 @@
 import type { Resource, RdfObjectLoader } from 'rdf-object';
 import type { Logger } from 'winston';
 import { IRIS_OWL } from '../rdf/Iris';
+import { uniqueTypes } from '../rdf/ResourceUtil';
 import { ErrorResourcesContext } from '../util/ErrorResourcesContext';
 import { GenericsContext } from './GenericsContext';
 import type { IConfigPreprocessorTransform, IConfigPreprocessor } from './IConfigPreprocessor';
@@ -28,14 +29,7 @@ export class ConfigPreprocessorComponent implements IConfigPreprocessor<ICompone
   public canHandle(config: Resource): IComponentConfigPreprocessorHandleResponse | undefined {
     if (!config.property.requireName) {
       // Collect all component types from the resource
-      const componentTypesIndex: Record<string, Resource> = {};
-      for (const type of config.properties.types) {
-        const componentResource: Resource = this.componentResources[type.value];
-        if (componentResource) {
-          componentTypesIndex[componentResource.value] = componentResource;
-        }
-      }
-      const componentTypes: Resource[] = Object.values(componentTypesIndex);
+      const componentTypes: Resource[] = uniqueTypes(config, this.componentResources);
 
       // Require either exactly one component type, or a requireName
       if (componentTypes.length > 1) {

--- a/lib/rdf/Iris.ts
+++ b/lib/rdf/Iris.ts
@@ -8,6 +8,9 @@ export const IRIS_OO = {
   ComponentInstance: PREFIX_OO('ComponentInstance'),
   component: PREFIX_OO('component'),
   componentPath: PREFIX_OO('componentPath'),
+  Override: PREFIX_OO('Override'),
+  overrideInstance: PREFIX_OO('overrideInstance'),
+  overrideParameters: PREFIX_OO('overrideParameters'),
   parameter: PREFIX_OO('parameter'),
 };
 

--- a/lib/rdf/ResourceUtil.ts
+++ b/lib/rdf/ResourceUtil.ts
@@ -1,0 +1,17 @@
+import type { Resource } from 'rdf-object';
+
+/**
+ * Filters duplicates from the types of the given {@link Resource} and returns all unique entries.
+ * @param resource - The {@link Resource} to filter the types of.
+ * @param componentResources - All the available component resources.
+ */
+export function uniqueTypes(resource: Resource, componentResources: Record<string, Resource>): Resource[] {
+  const componentTypesIndex: Record<string, Resource> = {};
+  for (const type of resource.properties.types) {
+    const componentResource: Resource = componentResources[type.value];
+    if (componentResource) {
+      componentTypesIndex[componentResource.value] = componentResource;
+    }
+  }
+  return Object.values(componentTypesIndex);
+}

--- a/test/unit/rdf/ResourceUtil-test.ts
+++ b/test/unit/rdf/ResourceUtil-test.ts
@@ -1,0 +1,43 @@
+import * as fs from 'fs';
+import type { Resource } from 'rdf-object';
+import { RdfObjectLoader } from 'rdf-object';
+import { uniqueTypes } from '../../../lib/rdf/ResourceUtil';
+
+describe('ResourceUtil', () => {
+  describe('uniqueTypes', () => {
+    let objectLoader: RdfObjectLoader;
+    let componentResources: Record<string, Resource>;
+
+    beforeEach(async() => {
+      objectLoader = new RdfObjectLoader({
+        context: JSON.parse(fs.readFileSync(`${__dirname}/../../../components/context.jsonld`, 'utf8')),
+      });
+      await objectLoader.context;
+
+      componentResources = {
+        'ex:Component': objectLoader.createCompactedResource({
+          '@id': 'ex:Component',
+          module: 'ex:Module',
+          parameters: [
+            { '@id': 'ex:param1' },
+            { '@id': 'ex:param2' },
+          ],
+        }),
+        'ex:ExtraType': objectLoader.createCompactedResource({
+          '@id': 'ex:ExtraType',
+          module: 'ex:Module',
+        }),
+      };
+    });
+
+    it('filters out duplicate types.', () => {
+      const resource = objectLoader.createCompactedResource({
+        '@id': 'ex:myComponentInstance',
+        types: [ 'ex:Component', 'ex:ExtraType', 'ex:Component' ],
+      });
+      expect(uniqueTypes(resource, componentResources)).toEqual(
+        [ componentResources['ex:Component'], componentResources['ex:ExtraType'] ],
+      );
+    });
+  });
+});


### PR DESCRIPTION
As discussed in https://github.com/LinkedSoftwareDependencies/Components.js/discussions/105#discussioncomment-3455593

I used the `componentResources` as an additional parameter since that is what `ConfigPreprocessorComponent` did, but I'm not actually sure why/if they're needed since all the resources with the same identifier seem to be the same everywhere. Using the `type` itself instead of `componentResources[type.value]` seemed to also work.

Also noticed there was a file with URI constants so used that for the override URIs.