### PR TITLE
Allow hash keys to be URIs that dereference to a string

### DIFF
--- a/lib/construction/argument/ArgumentConstructorHandlerHash.ts
+++ b/lib/construction/argument/ArgumentConstructorHandlerHash.ts
@@ -29,14 +29,16 @@ export class ArgumentConstructorHandlerHash implements IArgumentConstructorHandl
       if (!entry.property.key) {
         throw new ErrorResourcesContext(`Missing key in fields entry`, { entry, argument });
       }
-      if (entry.property.key.type !== 'Literal') {
-        throw new ErrorResourcesContext(`Illegal non-literal key (${entry.property.key.value} as ${entry.property.key.type}) in fields entry`, { entry, argument });
+
+      const key = await argsCreator.getArgumentValues(entry.properties.key, settings);
+      if (typeof key !== 'string') {
+        throw new ErrorResourcesContext(`Illegal non-string key (${entry.property.key.value} as ${entry.property.key.type}) in fields entry`, { entry, argument });
       }
 
       // Recursively get value arg value
       if (entry.property.value) {
         const subValue = await argsCreator.getArgumentValues(entry.properties.value, settings);
-        return { key: entry.property.key.value, value: subValue };
+        return { key, value: subValue };
       }
 
       // Ignore cases where value may not be set, because params may be optional


### PR DESCRIPTION
Closes https://github.com/LinkedSoftwareDependencies/Components.js/issues/115

Reason this already worked for values is because the `argsCreator` was called to determine the actual value of the value: https://github.com/LinkedSoftwareDependencies/Components.js/blob/10fb45d890d6d5095a7258183cb633d35735292c/lib/construction/argument/ArgumentConstructorHandlerHash.ts#L36-L40

I applied the same logic to the key.