### PR TITLE
Allow hash keys to be URIs that dereference to a string

### DIFF
--- a/lib/construction/argument/ArgumentConstructorHandlerHash.ts
+++ b/lib/construction/argument/ArgumentConstructorHandlerHash.ts
@@ -29,14 +29,16 @@ export class ArgumentConstructorHandlerHash implements IArgumentConstructorHandl
       if (!entry.property.key) {
         throw new ErrorResourcesContext(`Missing key in fields entry`, { entry, argument });
       }
-      if (entry.property.key.type !== 'Literal') {
-        throw new ErrorResourcesContext(`Illegal non-literal key (${entry.property.key.value} as ${entry.property.key.type}) in fields entry`, { entry, argument });
+
+      const key = await argsCreator.getArgumentValues(entry.properties.key, settings);
+      if (typeof key !== 'string') {
+        throw new ErrorResourcesContext(`Illegal non-string key (${entry.property.key.value} as ${entry.property.key.type}) in fields entry`, { entry, argument });
       }
 
       // Recursively get value arg value
       if (entry.property.value) {
         const subValue = await argsCreator.getArgumentValues(entry.properties.value, settings);
-        return { key: entry.property.key.value, value: subValue };
+        return { key, value: subValue };
       }
 
       // Ignore cases where value may not be set, because params may be optional

--- a/lib/construction/strategy/ConstructionStrategyCommonJsString.ts
+++ b/lib/construction/strategy/ConstructionStrategyCommonJsString.ts
@@ -94,7 +94,7 @@ export class ConstructionStrategyCommonJsString implements IConstructionStrategy
         }
         sb.push('\n');
         sb.push('  ');
-        sb.push(`'${entry.key}'`);
+        sb.push(`${entry.key}`);
         sb.push(': ');
         sb.push(entry.value);
       }

--- a/test/unit/construction/strategy/ConstructionStrategyCommonJsString-test.ts
+++ b/test/unit/construction/strategy/ConstructionStrategyCommonJsString-test.ts
@@ -290,14 +290,14 @@ module.exports = urn_comunica_sparqlinit;
       expect(constructionStrategy.createHash({
         settings,
         entries: [
-          { key: 'a', value: '1' },
-          { key: 'b', value: '2' },
-          { key: 'c', value: '3' },
+          { key: '"a"', value: '1' },
+          { key: '"b"', value: '2' },
+          { key: '"c"', value: '3' },
         ],
       })).toEqual(`{
-  'a': 1,
-  'b': 2,
-  'c': 3
+  "a": 1,
+  "b": 2,
+  "c": 3
 }`);
     });
 
@@ -305,13 +305,13 @@ module.exports = urn_comunica_sparqlinit;
       expect(constructionStrategy.createHash({
         settings,
         entries: [
-          { key: 'a', value: '1' },
+          { key: '"a"', value: '1' },
           undefined,
-          { key: 'c', value: '3' },
+          { key: '"c"', value: '3' },
         ],
       })).toEqual(`{
-  'a': 1,
-  'c': 3
+  "a": 1,
+  "c": 3
 }`);
     });
 
@@ -319,10 +319,10 @@ module.exports = urn_comunica_sparqlinit;
       expect(constructionStrategy.createHash({
         settings,
         entries: [
-          { key: 'a', value: '[\n  a,\n  b\n]' },
+          { key: '"a"', value: '[\n  a,\n  b\n]' },
         ],
       })).toEqual(`{
-  'a': [
+  "a": [
   a,
   b
 ]


### PR DESCRIPTION
Second attempt, see https://github.com/LinkedSoftwareDependencies/Components.js/pull/121

If you can provide me with what exactly with the commands that need to be tested on Comunica I can look into it.