### PR TITLE
Prevent literals from being cached

### DIFF
--- a/lib/loading/ComponentsManagerBuilder.ts
+++ b/lib/loading/ComponentsManagerBuilder.ts
@@ -68,6 +68,7 @@ export class ComponentsManagerBuilder<Instance = any> {
 
   public static createObjectLoader(): RdfObjectLoader {
     return new RdfObjectLoader({
+      uniqueLiterals: true,
       context: require('../../components/context.json'),
     });
   }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "jsonld-context-parser": "^2.1.1",
     "minimist": "^1.2.0",
     "rdf-data-factory": "^1.1.0",
-    "rdf-object": "^1.13.1",
+    "rdf-object": "^1.14.0",
     "rdf-parse": "^2.0.0",
     "rdf-quad": "^1.5.0",
     "rdf-string": "^1.6.0",

--- a/test/unit/construction/ConfigConstructor-test.ts
+++ b/test/unit/construction/ConfigConstructor-test.ts
@@ -20,6 +20,7 @@ describe('ConfigConstructor', () => {
 
   beforeEach(async() => {
     objectLoader = new RdfObjectLoader({
+      uniqueLiterals: true,
       context: JSON.parse(fs.readFileSync(`${__dirname}/../../../components/context.jsonld`, 'utf8')),
     });
     await objectLoader.context;

--- a/test/unit/construction/ConfigConstructorPool-test.ts
+++ b/test/unit/construction/ConfigConstructorPool-test.ts
@@ -22,6 +22,7 @@ describe('ConfigConstructorPool', () => {
   let parameterHandler: ParameterHandler;
   beforeEach(async() => {
     objectLoader = new RdfObjectLoader({
+      uniqueLiterals: true,
       context: JSON.parse(fs.readFileSync(`${__dirname}/../../../components/context.jsonld`, 'utf8')),
     });
     await objectLoader.context;

--- a/test/unit/loading/ComponentRegistry-test.ts
+++ b/test/unit/loading/ComponentRegistry-test.ts
@@ -17,6 +17,7 @@ describe('ComponentRegistry', () => {
       componentModules: {},
     };
     objectLoader = new RdfObjectLoader({
+      uniqueLiterals: true,
       context: JSON.parse(fs.readFileSync(`${__dirname}/../../../components/context.jsonld`, 'utf8')),
     });
     logger = <any> {

--- a/test/unit/loading/ComponentRegistryFinalizer-test.ts
+++ b/test/unit/loading/ComponentRegistryFinalizer-test.ts
@@ -19,6 +19,7 @@ describe('ComponentRegistryFinalizer', () => {
       componentModules: {},
     };
     objectLoader = new RdfObjectLoader({
+      uniqueLiterals: true,
       context: JSON.parse(fs.readFileSync(`${__dirname}/../../../components/context.jsonld`, 'utf8')),
     });
     logger = <any> {

--- a/test/unit/loading/ComponentsManager-test.ts
+++ b/test/unit/loading/ComponentsManager-test.ts
@@ -43,6 +43,7 @@ describe('ComponentsManager', () => {
       nodeModulePaths: [],
     };
     objectLoader = new RdfObjectLoader({
+      uniqueLiterals: true,
       context: JSON.parse(fs.readFileSync(`${__dirname}/../../../components/context.jsonld`, 'utf8')),
     });
     componentResources = {};

--- a/test/unit/loading/ConfigRegistry-test.ts
+++ b/test/unit/loading/ConfigRegistry-test.ts
@@ -16,6 +16,7 @@ describe('ConfigRegistry', () => {
       componentModules: {},
     };
     objectLoader = new RdfObjectLoader({
+      uniqueLiterals: true,
       context: JSON.parse(fs.readFileSync(`${__dirname}/../../../components/context.jsonld`, 'utf8')),
     });
     logger = <any>{

--- a/test/unit/preprocess/ConfigPreprocessorComponent-test.ts
+++ b/test/unit/preprocess/ConfigPreprocessorComponent-test.ts
@@ -19,6 +19,7 @@ describe('ConfigPreprocessorComponent', () => {
 
   beforeEach(async() => {
     objectLoader = new RdfObjectLoader({
+      uniqueLiterals: true,
       context: JSON.parse(fs.readFileSync(`${__dirname}/../../../components/context.jsonld`, 'utf8')),
     });
     await objectLoader.context;

--- a/test/unit/preprocess/ConfigPreprocessorComponentMapped-test.ts
+++ b/test/unit/preprocess/ConfigPreprocessorComponentMapped-test.ts
@@ -15,6 +15,7 @@ describe('ConfigPreprocessorComponentMapped', () => {
 
   beforeEach(async() => {
     objectLoader = new RdfObjectLoader({
+      uniqueLiterals: true,
       context: JSON.parse(fs.readFileSync(`${__dirname}/../../../components/context.jsonld`, 'utf8')),
     });
     await objectLoader.context;

--- a/test/unit/preprocess/ConfigPreprocessorOverride-test.ts
+++ b/test/unit/preprocess/ConfigPreprocessorOverride-test.ts
@@ -17,6 +17,7 @@ describe('ConfigPreprocessorOverride', () => {
 
   beforeEach(async() => {
     objectLoader = new RdfObjectLoader({
+      uniqueLiterals: true,
       context: JSON.parse(fs.readFileSync(`${__dirname}/../../../components/context.jsonld`, 'utf8')),
     });
     await objectLoader.context;

--- a/test/unit/preprocess/ParameterHandler-test.ts
+++ b/test/unit/preprocess/ParameterHandler-test.ts
@@ -14,6 +14,7 @@ describe('ParameterHandler', () => {
   let configElement: Resource;
   beforeEach(async() => {
     objectLoader = new RdfObjectLoader({
+      uniqueLiterals: true,
       context: JSON.parse(fs.readFileSync(`${__dirname}/../../../components/context.jsonld`, 'utf8')),
     });
     await objectLoader.context;

--- a/test/unit/preprocess/parameterproperty/ParameterPropertyHandlerRange-test.ts
+++ b/test/unit/preprocess/parameterproperty/ParameterPropertyHandlerRange-test.ts
@@ -37,6 +37,7 @@ describe('ParameterPropertyHandlerRange', () => {
   let genericsContext: GenericsContext;
   beforeEach(async() => {
     objectLoader = new RdfObjectLoader({
+      uniqueLiterals: true,
       context: JSON.parse(fs.readFileSync(`${__dirname}/../../../../components/context.jsonld`, 'utf8')),
     });
     await objectLoader.context;

--- a/test/unit/rdf/ResourceUtil-test.ts
+++ b/test/unit/rdf/ResourceUtil-test.ts
@@ -10,6 +10,7 @@ describe('ResourceUtil', () => {
 
     beforeEach(async() => {
       objectLoader = new RdfObjectLoader({
+        uniqueLiterals: true,
         context: JSON.parse(fs.readFileSync(`${__dirname}/../../../components/context.jsonld`, 'utf8')),
       });
       await objectLoader.context;

--- a/test/unit/util/ErrorResourcesContext-test.ts
+++ b/test/unit/util/ErrorResourcesContext-test.ts
@@ -7,6 +7,7 @@ describe('ErrorResourcesContext', () => {
 
   beforeEach(async() => {
     objectLoader = new RdfObjectLoader({
+      uniqueLiterals: true,
       context: JSON.parse(fs.readFileSync(`${__dirname}/../../../components/context.jsonld`, 'utf8')),
     });
     await objectLoader.context;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5190,10 +5190,10 @@ rdf-literal@^1.2.0:
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.0"
 
-rdf-object@^1.13.1:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/rdf-object/-/rdf-object-1.13.1.tgz#e88a7ebe93397b0e9877e89b855681d523065b1f"
-  integrity sha512-Sgq+GbsqdPsMYh+d4OZ4C9brXlzqa9MvfVHG4pkuT9p7o+AX39nqjTWE/8HVaXjjOZBIDe8T54WWTMWphu3BpA==
+rdf-object@^1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/rdf-object/-/rdf-object-1.14.0.tgz#a51a2e575d4f838f88eced1e5096616769d17281"
+  integrity sha512-/KSUWr7onDtL7d81kOpcUzJ2vHYOYJc2KU9WzBZRYydBhK0Sksh5Hg4VCQNaxUEvYEgdrrTuq9SLpOOCmag0rQ==
   dependencies:
     "@rdfjs/types" "*"
     jsonld-context-parser "^2.0.2"


### PR DESCRIPTION
Closes https://github.com/LinkedSoftwareDependencies/Components.js/issues/123 by using the new RDF object loader feature to not cache literals.

When this is merged, https://github.com/LinkedSoftwareDependencies/Components.js/pull/122 also causes no issues when running Comunica.