### PR TITLE
Add support for list overrides

### DIFF
--- a/components/context.jsonld
+++ b/components/context.jsonld
@@ -80,11 +80,45 @@
     "Override": {
       "@id": "oo:Override"
     },
+    "OverrideParameters": {
+      "@id": "oo:OverrideParameters"
+    },
+    "OverrideMapEntry": {
+      "@id": "oo:OverrideMapEntry"
+    },
+    "OverrideListInsertBefore": {
+      "@id": "oo:OverrideListInsertBefore"
+    },
+    "OverrideListInsertAfter": {
+      "@id": "oo:OverrideListInsertAfter"
+    },
+    "OverrideListInsertAt": {
+      "@id": "oo:OverrideListInsertAt"
+    },
+    "OverrideListRemove": {
+      "@id": "oo:OverrideListRemove"
+    },
     "overrideInstance": {
       "@id": "oo:overrideInstance"
     },
     "overrideParameters": {
       "@id": "oo:overrideParameters"
+    },
+    "overrideSteps": {
+      "@id": "oo:overrideSteps",
+      "@container": "@list"
+    },
+    "overrideParameter": {
+      "@id": "oo:overrideParameter",
+      "@container": "@list"
+    },
+    "overrideTarget": {
+      "@id": "oo:overrideTarget",
+      "@container": "@list"
+    },
+    "overrideValue": {
+      "@id": "oo:overrideValue",
+      "@container": "@list"
     },
     "ParameterRange": {
       "@id": "oo:ParameterRange"

--- a/lib/preprocess/overridesteps/IOverrideStep.ts
+++ b/lib/preprocess/overridesteps/IOverrideStep.ts
@@ -1,0 +1,26 @@
+import type { Resource } from 'rdf-object';
+
+/**
+ * Transforms a resource based on the contents of an override step.
+ */
+export interface IOverrideStep {
+  /**
+   * Determines if this handler can apply the given override step to the resource.
+   *
+   * @param config - The resource to override.
+   * @param step - The override step to apply.
+   *
+   * @returns true if this handler should be used.
+   */
+  canHandle: (config: Resource, step: Resource) => boolean;
+
+  /**
+   * Applies the changes described in the given override step to the resource.
+   *
+   * @param config - The resource to override.
+   * @param step - The override step to apply.
+   *
+   * @returns The modified resource.
+   */
+  handle: (config: Resource, step: Resource) => Resource;
+}

--- a/lib/preprocess/overridesteps/OverrideListInsertAfter.ts
+++ b/lib/preprocess/overridesteps/OverrideListInsertAfter.ts
@@ -1,0 +1,31 @@
+import type { Resource } from 'rdf-object';
+import { PREFIX_OO } from '../../rdf/Iris';
+import type { IOverrideStep } from './IOverrideStep';
+import { extractOverrideStepFields, findResourceIndex, getPropertyResourceList } from './OverrideUtil';
+
+/**
+ * Override step that inserts elements in a list after a specific element.
+ *
+ * Uses the following override step fields:
+ *  - `overrideParameter`: Parameter of the original object that contains the list.
+ *  - `overrideTarget`: Element already in the list that is used as reference. This can be a named node or a literal.
+ *  - `overrideValue`: Element(s) to insert immediately after the target element.
+ */
+export class OverrideListInsertAfter implements IOverrideStep {
+  public canHandle(config: Resource, step: Resource): boolean {
+    return step.property.type.value === PREFIX_OO('OverrideListInsertAfter');
+  }
+
+  public handle(config: Resource, step: Resource): Resource {
+    const { parameters, targets, values } = extractOverrideStepFields(step, { parameters: 1, targets: 1 });
+
+    const list = getPropertyResourceList(config, parameters[0]);
+
+    const index = findResourceIndex(list, targets[0]);
+
+    // +1 so we start after the selected element
+    list.splice(index + 1, 0, ...values);
+
+    return config;
+  }
+}

--- a/lib/preprocess/overridesteps/OverrideListInsertAt.ts
+++ b/lib/preprocess/overridesteps/OverrideListInsertAt.ts
@@ -1,0 +1,45 @@
+import type { Resource } from 'rdf-object';
+import { PREFIX_OO } from '../../rdf/Iris';
+import { ErrorResourcesContext } from '../../util/ErrorResourcesContext';
+import type { IOverrideStep } from './IOverrideStep';
+import { extractOverrideStepFields, getPropertyResourceList } from './OverrideUtil';
+
+/**
+ * Override step that inserts elements in a list at a specific index.
+ * A negative index can be used to count from the back of the list.
+ * An index of `-0` can be used to insert at the end of the list.
+ *
+ * Uses the following override step fields:
+ *  - `overrideParameter`: Parameter of the original object that contains the list.
+ *  - `overrideTarget`: A literal containing the index.
+ *  - `overrideValue`: Element(s) to insert at the chosen index.
+ */
+export class OverrideListInsertAt implements IOverrideStep {
+  public canHandle(config: Resource, step: Resource): boolean {
+    return step.property.type.value === PREFIX_OO('OverrideListInsertAt');
+  }
+
+  public handle(config: Resource, step: Resource): Resource {
+    const { parameters, targets, values } = extractOverrideStepFields(step, { parameters: 1, targets: 1 });
+
+    const list = getPropertyResourceList(config, parameters[0]);
+
+    const val = targets[0].value;
+    if (!/^-?\d+$/u.test(val)) {
+      throw new ErrorResourcesContext(`Invalid index in Override step OverrideListInsertAt for parameter ${parameters[0].value}: ${val}`, {
+        config,
+        step,
+      });
+    }
+
+    // Support adding elements at the end using -0
+    if (val === '-0') {
+      list.push(...values);
+    } else {
+      const index = Number.parseInt(val, 10);
+      list.splice(index, 0, ...values);
+    }
+
+    return config;
+  }
+}

--- a/lib/preprocess/overridesteps/OverrideListInsertBefore.ts
+++ b/lib/preprocess/overridesteps/OverrideListInsertBefore.ts
@@ -1,0 +1,30 @@
+import type { Resource } from 'rdf-object';
+import { PREFIX_OO } from '../../rdf/Iris';
+import type { IOverrideStep } from './IOverrideStep';
+import { extractOverrideStepFields, findResourceIndex, getPropertyResourceList } from './OverrideUtil';
+
+/**
+ * Override step that inserts elements in a list before a specific element.
+ *
+ * Uses the following override step fields:
+ *  - `overrideParameter`: Parameter of the original object that contains the list.
+ *  - `overrideTarget`: Element already in the list that is used as reference. This can be a named node or a literal.
+ *  - `overrideValue`: Element(s) to insert immediately before the target element.
+ */
+export class OverrideListInsertBefore implements IOverrideStep {
+  public canHandle(config: Resource, step: Resource): boolean {
+    return step.property.type.value === PREFIX_OO('OverrideListInsertBefore');
+  }
+
+  public handle(config: Resource, step: Resource): Resource {
+    const { parameters, targets, values } = extractOverrideStepFields(step, { parameters: 1, targets: 1 });
+
+    const list = getPropertyResourceList(config, parameters[0]);
+
+    const index = findResourceIndex(list, targets[0]);
+
+    list.splice(index, 0, ...values);
+
+    return config;
+  }
+}

--- a/lib/preprocess/overridesteps/OverrideListRemove.ts
+++ b/lib/preprocess/overridesteps/OverrideListRemove.ts
@@ -1,0 +1,37 @@
+import type { Resource } from 'rdf-object';
+import { PREFIX_OO } from '../../rdf/Iris';
+import type { IOverrideStep } from './IOverrideStep';
+import { extractOverrideStepFields, findResourceIndex, getPropertyResourceList } from './OverrideUtil';
+
+/**
+ * Override step that removes specified elements.
+ *
+ * Uses the following override step fields:
+ *  - `overrideParameter`: Parameter of the original object that contains the list.
+ *  - `overrideTarget`: Element(s) already in the list that need to be removed. These can be named nodes or literals.
+ */
+export class OverrideListRemove implements IOverrideStep {
+  public canHandle(config: Resource, step: Resource): boolean {
+    return step.property.type.value === PREFIX_OO('OverrideListRemove');
+  }
+
+  public handle(config: Resource, step: Resource): Resource {
+    const { parameters, targets, values } = extractOverrideStepFields(step, { parameters: 1, values: 0 });
+
+    const list = getPropertyResourceList(config, parameters[0]);
+
+    const indexes: number[] = [];
+    for (const element of targets) {
+      indexes.push(findResourceIndex(list, element));
+    }
+
+    // Highest number first so indexes remain correct while sorting
+    indexes.sort((left, right) => right - left);
+
+    for (const index of indexes) {
+      list.splice(index, 1);
+    }
+
+    return config;
+  }
+}

--- a/lib/preprocess/overridesteps/OverrideMapEntry.ts
+++ b/lib/preprocess/overridesteps/OverrideMapEntry.ts
@@ -1,0 +1,88 @@
+import type { Resource } from 'rdf-object';
+import { PREFIX_OO } from '../../rdf/Iris';
+import { ErrorResourcesContext } from '../../util/ErrorResourcesContext';
+import type { IOverrideStep } from './IOverrideStep';
+import { extractOverrideStepFields, getPropertyResourceList } from './OverrideUtil';
+
+/**
+ * Override step that updates an entry in a key/value map.
+ *
+ * Uses the following override step fields:
+ *  - `overrideParameter`: Parameter of the original object that contains the key/value map.
+ *  - `overrideTarget`: The key that needs to be updated.
+ *  - `overrideValue`: The new value for the key. In case this is not defined, the key will be deleted instead.
+ */
+export class OverrideMapEntry implements IOverrideStep {
+  public canHandle(config: Resource, step: Resource): boolean {
+    return step.property.type.value === PREFIX_OO('OverrideMapEntry');
+  }
+
+  public handle(config: Resource, step: Resource): Resource {
+    const { parameters, targets, values } = extractOverrideStepFields(step, { parameters: 1, targets: 1 });
+
+    const properties = this.findProperties(config.property.type, parameters[0]);
+
+    const entries = getPropertyResourceList(config, parameters[0]);
+    const index = this.findEntryIndex(entries, targets[0], properties);
+
+    if (values.length === 0) {
+      // Remove the entry
+      entries.splice(index, 1);
+    } else {
+      // Replace the value of the entry
+      entries[index].properties[properties.value.value] = values;
+    }
+
+    return config;
+  }
+
+  /**
+   * Finds the URIs used to link to the key and value of a map entry.
+   *
+   * @param type - Type of the class that contains the key/value map.
+   * @param parameter - Parameter of the class used to link to the key/value map.
+   */
+  protected findProperties(type: Resource, parameter: Resource): { key: Resource; value: Resource } {
+    const constructArgs = type.property.constructorArguments.list ?? [];
+    for (const arg of constructArgs) {
+      const fields = arg.property.fields.list ?? [];
+      for (const field of fields) {
+        let collectEntries = field.property.collectEntries;
+        // Not sure when this is not a list in practice.
+        // Based on behaviour in `ConstructorArgumentsElementMappingHandlerCollectEntries`.
+        if (collectEntries.list) {
+          collectEntries = collectEntries.list[0];
+        }
+        if (collectEntries.term.equals(parameter.term)) {
+          return { key: field.property.key, value: field.property.value };
+        }
+      }
+    }
+
+    throw new ErrorResourcesContext(`Unable to find key/value URIs for parameter ${parameter.value}`, {
+      type,
+      parameter,
+    });
+  }
+
+  /**
+   * Finds the index in a list of key/value map entries of the entry with the matching key.
+   *
+   * @param entries - List of key/value map entries.
+   * @param key - Key of the entry to find.
+   * @param properties - URIs used to link the key and value of a map entry.
+   */
+  protected findEntryIndex(entries: Resource[], key: Resource, properties: { key: Resource; value: Resource }): number {
+    for (const [ i, entry ] of entries.entries()) {
+      if (key.term.equals(entry.property[properties.key.value].term)) {
+        return i;
+      }
+    }
+
+    throw new ErrorResourcesContext(`Unable to find key/value entry with key ${key.value}`, {
+      entries,
+      key,
+      properties,
+    });
+  }
+}

--- a/lib/preprocess/overridesteps/OverrideParameters.ts
+++ b/lib/preprocess/overridesteps/OverrideParameters.ts
@@ -1,0 +1,41 @@
+import type { Resource } from 'rdf-object';
+import { PREFIX_OO } from '../../rdf/Iris';
+import type { IOverrideStep } from './IOverrideStep';
+import { extractOverrideStepFields } from './OverrideUtil';
+
+/**
+ * Override step that replaces properties of the target object.
+ * Only the specified parameters will be replaced,
+ * others will keep their original value.
+ * In case the type is changed all original values will be removed.
+ *
+ * Uses the following override step fields:
+ *  - `overrideValue`: New properties for the object.
+ */
+export class OverrideParameters implements IOverrideStep {
+  public canHandle(config: Resource, step: Resource): boolean {
+    return step.property.type.value === PREFIX_OO('OverrideParameters');
+  }
+
+  public handle(config: Resource, step: Resource): Resource {
+    const { values } = extractOverrideStepFields(step, { parameters: 0, targets: 0, values: 1 });
+    const partialResource = values[0];
+
+    // In case the step has a different type, the properties of the previous step don't matter any more,
+    // as the object is being replaced completely.
+    const originalType = config.property.type.term;
+    const newType = partialResource.property.type?.term;
+
+    // In case the type changes we have to delete all the original properties as those correspond to the old type
+    if (newType && !newType.equals(originalType)) {
+      for (const id of Object.keys(config.properties)) {
+        delete config.properties[id];
+      }
+    }
+    for (const property of Object.keys(partialResource.properties)) {
+      config.properties[property] = partialResource.properties[property];
+    }
+
+    return config;
+  }
+}

--- a/lib/preprocess/overridesteps/OverrideUtil.ts
+++ b/lib/preprocess/overridesteps/OverrideUtil.ts
@@ -1,0 +1,88 @@
+import type { Resource } from 'rdf-object';
+import { PREFIX_OO } from '../../rdf/Iris';
+import { ErrorResourcesContext } from '../../util/ErrorResourcesContext';
+
+export const OVERRIDE_STEP_FIELD_NAMES = [ 'parameter', 'target', 'value' ] as const;
+export type OverrideStepFieldName = `${typeof OVERRIDE_STEP_FIELD_NAMES[number]}s`;
+
+/**
+ * Extracts the fields from an override step and checks if the correct amount is present.
+ * Will throw an error if the amount doesn't match what is expected.
+ *
+ * @param step - Override step to get the fields from.
+ * @param expected - For each field, how many are expected. The value can be undefined if there is no fixed amount.
+ */
+export function extractOverrideStepFields(step: Resource, expected: { [key in OverrideStepFieldName]?: number } = {}):
+Record<OverrideStepFieldName, Resource[]> {
+  // Type is not correct yet now but will be completed in the loop below
+  const result = <Record<OverrideStepFieldName, Resource[]>> {};
+
+  for (const key of OVERRIDE_STEP_FIELD_NAMES) {
+    const overrideKey = `override${key[0].toUpperCase()}${key.slice(1)}`;
+    const propertiesKey = `${key}s` as const;
+    const properties = step.properties[PREFIX_OO(overrideKey)];
+    if (properties.length > 1) {
+      throw new ErrorResourcesContext(`Detected multiple values for ${overrideKey} in Override step ${step.value}. RDF lists should be used for defining multiple values.`, {
+        overrideStep: step,
+      });
+    }
+
+    const list = properties[0]?.list ?? properties;
+
+    if (typeof expected[propertiesKey] === 'number' && list.length !== expected[propertiesKey]) {
+      throw new ErrorResourcesContext(`Expected ${expected[propertiesKey]} entries for ${overrideKey} but found ${list.length} in Override step ${step.value}`, {
+        overrideStep: step,
+      });
+    }
+    result[propertiesKey] = list;
+  }
+
+  return result;
+}
+
+/**
+ * Returns a list containing all values for the given resource found with the given property.
+ * In case there are multiple matches, the lists will be merged.
+ * The parameter of the resource will be updated to have a single value which is the returned list,
+ * so the returned list can be updated to modify the resource directly.
+ *
+ * @param config
+ * @param parameter
+ */
+export function getPropertyResourceList(config: Resource, parameter: Resource): Resource[] {
+  const properties = config.properties[parameter.value];
+  if (!properties || properties.length === 0) {
+    return [];
+  }
+
+  // Having multiple lists can happen if multiple config files add elements to the same list
+  const list = properties.flatMap(prop => prop.list);
+  if (list.some(res => res === undefined)) {
+    throw new ErrorResourcesContext(`Invalid target in Override step targeting ${config.value}: ${parameter.value} does not reference a list`, {
+      config,
+    });
+  }
+
+  config.properties[parameter.value] = [ properties[0] ];
+  properties[0].list = <Resource[]>list;
+
+  return properties[0].list;
+}
+
+/**
+ * Finds the index of the given resource in the given list.
+ * Will throw an error if the resource is not found.
+ *
+ * @param list - The list to find the resource in.
+ * @param target - The resource to find.
+ */
+export function findResourceIndex(list: Resource[], target: Resource): number {
+  const index = list.findIndex((element): boolean => element.term.equals(target.term));
+  if (index < 0) {
+    throw new ErrorResourcesContext(`Unable to find ${target.value} in targeted list while overriding.`, {
+      target,
+      list,
+    });
+  }
+  return index;
+}

--- a/lib/rdf/Iris.ts
+++ b/lib/rdf/Iris.ts
@@ -11,6 +11,7 @@ export const IRIS_OO = {
   Override: PREFIX_OO('Override'),
   overrideInstance: PREFIX_OO('overrideInstance'),
   overrideParameters: PREFIX_OO('overrideParameters'),
+  overrideSteps: PREFIX_OO('overrideSteps'),
   parameter: PREFIX_OO('parameter'),
 };
 

--- a/test/unit/preprocess/ConfigPreprocessorOverride-test.ts
+++ b/test/unit/preprocess/ConfigPreprocessorOverride-test.ts
@@ -1,47 +1,27 @@
 import 'jest-rdf';
-import * as fs from 'fs';
+import type { Term } from '@rdfjs/types';
 import { DataFactory } from 'rdf-data-factory';
-import type { Resource } from 'rdf-object';
-import { RdfObjectLoader } from 'rdf-object';
+import type { RdfObjectLoader } from 'rdf-object';
 import type { Logger } from 'winston';
 import { ConfigPreprocessorOverride } from '../../../lib/preprocess/ConfigPreprocessorOverride';
-import { IRIS_OO } from '../../../lib/rdf/Iris';
+import { IRIS_OO, PREFIX_OO } from '../../../lib/rdf/Iris';
+import { setupObjectLoader } from './overrideSteps/OverrideTestUtil';
 
 const DF = new DataFactory();
 
 describe('ConfigPreprocessorOverride', () => {
   let objectLoader: RdfObjectLoader;
-  let componentResources: Record<string, Resource>;
   let logger: Logger;
   let preprocessor: ConfigPreprocessorOverride;
 
   beforeEach(async() => {
-    objectLoader = new RdfObjectLoader({
-      uniqueLiterals: true,
-      context: JSON.parse(fs.readFileSync(`${__dirname}/../../../components/context.jsonld`, 'utf8')),
-    });
-    await objectLoader.context;
-
-    componentResources = {
-      'ex:Component': objectLoader.createCompactedResource({
-        '@id': 'ex:Component',
-        module: 'ex:Module',
-        parameters: [
-          { '@id': 'ex:param1' },
-          { '@id': 'ex:param2' },
-        ],
-      }),
-      'ex:ExtraType': objectLoader.createCompactedResource({
-        '@id': 'ex:ExtraType',
-        module: 'ex:Module',
-      }),
-    };
+    objectLoader = await setupObjectLoader();
     logger = <any> {
       warn: jest.fn(),
     };
     preprocessor = new ConfigPreprocessorOverride({
       objectLoader,
-      componentResources,
+      componentResources: objectLoader.resources,
       logger,
     });
   });
@@ -63,40 +43,132 @@ describe('ConfigPreprocessorOverride', () => {
       '@id': 'ex:myOverride',
       types: 'oo:Override',
       overrideInstance: 'ex:myComponentInstance',
-      overrideParameters: {
-        'ex:param1': '"hello"',
+      overrideSteps: {
+        '@type': 'OverrideParameters',
+        overrideValue: {
+          'ex:param1': '"hello"',
+        },
       },
     });
-    const overrideProperties = overrideInstance.properties[IRIS_OO.overrideParameters][0].properties;
+    const overrideProperties =
+      overrideInstance.property[IRIS_OO.overrideSteps].property[PREFIX_OO('overrideValue')].property;
     const override = preprocessor.canHandle(config);
-    expect(override).not.toBeUndefined();
-    expect(Object.keys(override!).length).toBe(1);
-    expect(override!['ex:param1']).toBe(overrideProperties['ex:param1'][0]);
+    expect(override).toBeDefined();
+    expect(override).toHaveLength(1);
+
+    preprocessor.transform(config, override!);
+    expect(config.property['ex:param1']).toBe(overrideProperties['ex:param1']);
   });
 
-  it('should only override the relevant parameters of a resource', () => {
+  it('should handle resources with an override in the simplified format', () => {
     const config = objectLoader.createCompactedResource({
       '@id': 'ex:myComponentInstance',
       types: 'ex:Component',
-      'ex:param1': '"value1"',
-      'ex:param2': '"value2"',
     });
     const overrideInstance = objectLoader.createCompactedResource({
       '@id': 'ex:myOverride',
       types: 'oo:Override',
       overrideInstance: 'ex:myComponentInstance',
       overrideParameters: {
-        'ex:param1': '"updatedValue"',
+        'ex:param1': '"hello"',
       },
     });
-    const overrideProperties = overrideInstance.properties[IRIS_OO.overrideParameters][0].properties;
+    const overrideProperties = overrideInstance.property[IRIS_OO.overrideParameters].property;
+    const override = preprocessor.canHandle(config);
+    expect(override).toBeDefined();
+    expect(override).toHaveLength(1);
+
+    preprocessor.transform(config, override!);
+    expect(config.property['ex:param1']).toBe(overrideProperties['ex:param1']);
+  });
+
+  it('can perform multiple steps in a single override.', async(): Promise<void> => {
+    // This tests all the step handlers in the ConfigPreprocessorOverride
+    const config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+      types: 'ex:Component',
+      'ex:param1': '"value1"',
+      'ex:param2': '"value2"',
+      'ex:paramList': {
+        list: [ '"list1"', '"list2"', '"list3"', '"list4"' ],
+      },
+      'ex:paramMap': {
+        list: [
+          {
+            'ex:paramMap_key': '"key"',
+            'ex:paramMap_value': '"value"',
+          },
+        ],
+      },
+    });
+
+    objectLoader.createCompactedResource({
+      '@id': 'ex:myOverride',
+      types: 'oo:Override',
+      overrideInstance: 'ex:myComponentInstance',
+      overrideSteps: { list: [
+        {
+          '@type': 'OverrideParameters',
+          overrideValue: {
+            'ex:param1': '"newValue1"',
+            'ex:paramList': { list: [ '"newList1"', '"newList2"', '"newList3"' ]},
+          },
+        },
+        {
+          '@type': 'OverrideListInsertAfter',
+          overrideParameter: { '@id': 'ex:paramList' },
+          overrideTarget: '"newList2"',
+          overrideValue: '"addedAfter"',
+        },
+        {
+          '@type': 'OverrideListInsertBefore',
+          overrideParameter: { '@id': 'ex:paramList' },
+          overrideTarget: '"addedAfter"',
+          overrideValue: '"addedBefore"',
+        },
+        {
+          '@type': 'OverrideListRemove',
+          overrideParameter: { '@id': 'ex:paramList' },
+          overrideTarget: '"newList1"',
+        },
+        {
+          '@type': 'OverrideListInsertAt',
+          overrideParameter: { '@id': 'ex:paramList' },
+          overrideTarget: '2',
+          overrideValue: { list: [ '"addedAt1"', '"addedAt2"' ]},
+        },
+        {
+          '@type': 'OverrideMapEntry',
+          overrideParameter: { '@id': 'ex:paramMap' },
+          overrideTarget: '"key"',
+          overrideValue: '"updatedValue"',
+        },
+      ]},
+    });
     const override = preprocessor.canHandle(config)!;
+
     const { rawConfig, finishTransformation } = preprocessor.transform(config, override);
     expect(finishTransformation).toBe(false);
     expect(rawConfig).toBe(config);
-    expect(rawConfig.properties['ex:param1'][0]).toBe(overrideProperties['ex:param1'][0]);
-    expect(rawConfig.properties['ex:param1'][0].value).toBe('updatedValue');
-    expect(rawConfig.properties['ex:param2'][0].value).toBe('value2');
+    expect(rawConfig.properties['ex:param1'][0].term).toEqual(DF.literal('newValue1'));
+    expect(rawConfig.properties['ex:param2'][0].term).toEqual(DF.literal('value2'));
+    expect(config.properties['ex:paramList'][0].list?.map(res => res.term))
+      .toEqual([
+        DF.literal('newList2'),
+        DF.literal('addedBefore'),
+        DF.literal('addedAt1'),
+        DF.literal('addedAt2'),
+        DF.literal('addedAfter'),
+        DF.literal('newList3'),
+      ]);
+    const entryList = config.property['ex:paramMap'].list;
+    const entries = entryList?.map((entry): { key: Term; value: Term } => ({
+      key: entry.property['ex:paramMap_key'].term,
+      value: entry.property['ex:paramMap_value'].term,
+    }));
+    expect(entries).toEqual([
+      { key: DF.literal('key'), value: DF.literal('updatedValue') },
+    ]);
   });
 
   it('can chain overrides', () => {
@@ -106,7 +178,7 @@ describe('ConfigPreprocessorOverride', () => {
       'ex:param1': '"value1"',
       'ex:param2': '"value2"',
     });
-    const overrideInstance1 = objectLoader.createCompactedResource({
+    objectLoader.createCompactedResource({
       '@id': 'ex:myOverride1',
       types: 'oo:Override',
       overrideInstance: 'ex:myComponentInstance',
@@ -115,27 +187,27 @@ describe('ConfigPreprocessorOverride', () => {
         'ex:param2': '"value2-1"',
       },
     });
-    const overrideInstance2 = objectLoader.createCompactedResource({
+    objectLoader.createCompactedResource({
       '@id': 'ex:myOverride2',
       types: 'oo:Override',
       overrideInstance: 'ex:myOverride1',
-      overrideParameters: {
-        'ex:param1': '"value1-2"',
+      overrideSteps: {
+        '@type': 'OverrideParameters',
+        overrideValue: {
+          'ex:param1': '"value1-2"',
+        },
       },
     });
-    const override1Properties = overrideInstance1.properties[IRIS_OO.overrideParameters][0].properties;
-    const override2Properties = overrideInstance2.properties[IRIS_OO.overrideParameters][0].properties;
     const override = preprocessor.canHandle(config)!;
+
     const { rawConfig, finishTransformation } = preprocessor.transform(config, override);
     expect(finishTransformation).toBe(false);
     expect(rawConfig).toBe(config);
-    expect(rawConfig.properties['ex:param1'][0]).toBe(override2Properties['ex:param1'][0]);
-    expect(rawConfig.properties['ex:param1'][0].value).toBe('value1-2');
-    expect(rawConfig.properties['ex:param2'][0]).toBe(override1Properties['ex:param2'][0]);
-    expect(rawConfig.properties['ex:param2'][0].value).toBe('value2-1');
+    expect(rawConfig.properties['ex:param1'][0].term).toEqual(DF.literal('value1-2'));
+    expect(rawConfig.properties['ex:param2'][0].term).toEqual(DF.literal('value2-1'));
   });
 
-  it('caches the overrides', () => {
+  it('caches the override steps', () => {
     const config = objectLoader.createCompactedResource({
       '@id': 'ex:myComponentInstance',
       types: 'ex:Component',
@@ -148,11 +220,10 @@ describe('ConfigPreprocessorOverride', () => {
         'ex:param1': '"value1-1"',
       },
     });
-    const override1Properties = overrideInstance1.properties[IRIS_OO.overrideParameters][0].properties;
+    const override1Properties = overrideInstance1.property[IRIS_OO.overrideParameters].property;
     let override = preprocessor.canHandle(config);
     expect(override).not.toBeUndefined();
-    expect(Object.keys(override!).length).toBe(1);
-    expect(override!['ex:param1']).toBe(override1Properties['ex:param1'][0]);
+    expect(override).toHaveLength(1);
 
     objectLoader.createCompactedResource({
       '@id': 'ex:myOverride2',
@@ -165,9 +236,10 @@ describe('ConfigPreprocessorOverride', () => {
     // `ex:myOverride2` will not be applied due to cache
     override = preprocessor.canHandle(config);
     expect(override).not.toBeUndefined();
-    expect(Object.keys(override!).length).toBe(1);
-    expect(override!['ex:param1']).toBe(override1Properties['ex:param1'][0]);
-    expect(override!['ex:param1'].value).toBe('value1-1');
+    expect(override).toHaveLength(1);
+    preprocessor.transform(config, override!);
+    expect(config.property['ex:param1']).toBe(override1Properties['ex:param1']);
+    expect(config.property['ex:param1'].value).toBe('value1-1');
   });
 
   it('can reset the override cache', () => {
@@ -183,11 +255,10 @@ describe('ConfigPreprocessorOverride', () => {
         'ex:param1': '"value1-1"',
       },
     });
-    const override1Properties = overrideInstance1.properties[IRIS_OO.overrideParameters][0].properties;
+
     let override = preprocessor.canHandle(config);
     expect(override).not.toBeUndefined();
-    expect(Object.keys(override!).length).toBe(1);
-    expect(override!['ex:param1']).toBe(override1Properties['ex:param1'][0]);
+    expect(override).toHaveLength(1);
 
     const overrideInstance2 = objectLoader.createCompactedResource({
       '@id': 'ex:myOverride2',
@@ -197,17 +268,33 @@ describe('ConfigPreprocessorOverride', () => {
         'ex:param1': '"value1-2"',
       },
     });
-    const override2Properties = overrideInstance2.properties[IRIS_OO.overrideParameters][0].properties;
+    const override2Properties = overrideInstance2.property[IRIS_OO.overrideParameters].property;
     // `ex:myOverride2` is applied if we reset
     preprocessor.reset();
     override = preprocessor.canHandle(config);
     expect(override).not.toBeUndefined();
-    expect(Object.keys(override!).length).toBe(1);
-    expect(override!['ex:param1']).toBe(override2Properties['ex:param1'][0]);
-    expect(override!['ex:param1'].value).toBe('value1-2');
+    expect(override).toHaveLength(2);
+    preprocessor.transform(config, override!);
+    expect(config.property['ex:param1']).toBe(override2Properties['ex:param1']);
+    expect(config.property['ex:param1'].value).toBe('value1-2');
   });
 
   it('logs a warning if if an Override has no target', () => {
+    const config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+      types: 'ex:Component',
+    });
+    objectLoader.createCompactedResource({
+      '@id': 'ex:myOverride',
+      types: 'oo:Override',
+      overrideInstance: 'ex:myComponentInstance',
+    });
+    expect(preprocessor.canHandle(config)).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenLastCalledWith(`No steps found for Override ex:myOverride. This Override will be ignored.`);
+  });
+
+  it('logs a warning if if an Override has no steps', () => {
     const config = objectLoader.createCompactedResource({
       '@id': 'ex:myComponentInstance',
       types: 'ex:Component',
@@ -224,22 +311,6 @@ describe('ConfigPreprocessorOverride', () => {
     expect(logger.warn).toHaveBeenLastCalledWith(`Missing overrideInstance for ex:myOverride. This Override will be ignored.`);
   });
 
-  it('logs a warning if there is an Override with no specified parameters', () => {
-    const config = objectLoader.createCompactedResource({
-      '@id': 'ex:myComponentInstance',
-      types: 'ex:Component',
-    });
-    objectLoader.createCompactedResource({
-      '@id': 'ex:myOverride',
-      types: 'oo:Override',
-      overrideInstance: 'ex:myComponentInstance',
-    });
-    preprocessor.canHandle(config);
-    expect(preprocessor.canHandle(config)).toBeUndefined();
-    expect(logger.warn).toHaveBeenCalledTimes(1);
-    expect(logger.warn).toHaveBeenLastCalledWith(`No overrideParameters found for ex:myOverride.`);
-  });
-
   it('errors if an Override has multiple targets', () => {
     const config = objectLoader.createCompactedResource({
       '@id': 'ex:myComponentInstance',
@@ -254,6 +325,21 @@ describe('ConfigPreprocessorOverride', () => {
       },
     });
     expect(() => preprocessor.canHandle(config)).toThrow(`Detected multiple overrideInstance targets for ex:myOverride`);
+  });
+
+  it('errors if an Override has multiple steps without using a list', () => {
+    const config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+      types: 'ex:Component',
+    });
+    objectLoader.createCompactedResource({
+      '@id': 'ex:myOverride',
+      types: 'oo:Override',
+      overrideInstance: 'ex:myComponentInstance',
+      overrideSteps: [{}, {}],
+    });
+    expect(() => preprocessor.canHandle(config))
+      .toThrow(`Detected multiple values for overrideSteps in Override ex:myOverride. RDF lists should be used for defining multiple values.`);
   });
 
   it('errors if a resource has multiple Overrides targeting it', () => {
@@ -324,11 +410,12 @@ describe('ConfigPreprocessorOverride', () => {
         'ex:param1': '"hello"',
       },
     });
-    const overrideProperties = overrideInstance.properties[IRIS_OO.overrideParameters][0].properties;
+    const overrideProperties = overrideInstance.property[IRIS_OO.overrideParameters].property;
     const override = preprocessor.canHandle(config);
     expect(override).not.toBeUndefined();
-    expect(Object.keys(override!).length).toBe(1);
-    expect(override!['ex:param1']).toBe(overrideProperties['ex:param1'][0]);
+    expect(override).toHaveLength(1);
+    expect(() => preprocessor.transform(config, override!)).not.toThrow();
+    expect(config.property['ex:param1']).toBe(overrideProperties['ex:param1']);
   });
 
   it('errors if an Override has multiple overrideParameters objects', () => {
@@ -348,7 +435,7 @@ describe('ConfigPreprocessorOverride', () => {
     expect(() => preprocessor.canHandle(config)).toThrow(`Detected multiple values for overrideParameters in Override ex:myOverride`);
   });
 
-  it('errors if an overrideParameters entry has multiple values', () => {
+  it('errors if no override handler supports a specific step', () => {
     const config = objectLoader.createCompactedResource({
       '@id': 'ex:myComponentInstance',
       types: 'ex:Component',
@@ -357,83 +444,11 @@ describe('ConfigPreprocessorOverride', () => {
       '@id': 'ex:myOverride',
       types: 'oo:Override',
       overrideInstance: 'ex:myComponentInstance',
-      overrideParameters: {
-        'ex:param1': [ '"hello"', '"bye"' ],
+      overrideSteps: {
+        '@type': 'UnknownOverride',
       },
     });
-    expect(() => preprocessor.canHandle(config)).toThrow(`Detected multiple values for override parameter ex:param1 in Override ex:myOverride. RDF lists should be used for defining multiple values.`);
-  });
-
-  it('can replace the type of an object.', async(): Promise<void> => {
-    const config = objectLoader.createCompactedResource({
-      '@id': 'ex:myComponentInstance',
-      types: 'ex:Component',
-      'ex:param1': '"value1"',
-      'ex:param2': '"value2"',
-    });
-    const overrideInstance = objectLoader.createCompactedResource({
-      '@id': 'ex:myOverride',
-      types: 'oo:Override',
-      overrideInstance: 'ex:myComponentInstance',
-      overrideParameters: {
-        '@type': 'ex:ExtraType',
-        'ex:param3': '"hello"',
-      },
-    });
-    const overrideProperties = overrideInstance.properties[IRIS_OO.overrideParameters][0].properties;
-    const override = preprocessor.canHandle(config)!;
-    const { rawConfig, finishTransformation } = preprocessor.transform(config, override);
-    expect(finishTransformation).toBe(false);
-    expect(rawConfig).toBe(config);
-    expect(rawConfig.properties['ex:param3'][0]).toBe(overrideProperties['ex:param3'][0]);
-    expect(rawConfig.properties['ex:param1']).toHaveLength(0);
-    expect(rawConfig.properties['ex:param2']).toHaveLength(0);
-  });
-
-  it('can chain type changes', () => {
-    const config = objectLoader.createCompactedResource({
-      '@id': 'ex:myComponentInstance',
-      types: 'ex:Component',
-      'ex:param1': '"value1"',
-      'ex:param2': '"value2"',
-    });
-    const overrideInstance1 = objectLoader.createCompactedResource({
-      '@id': 'ex:myOverride1',
-      types: 'oo:Override',
-      overrideInstance: 'ex:myComponentInstance',
-      overrideParameters: {
-        'ex:param1': '"value1-1"',
-      },
-    });
-    const overrideInstance2 = objectLoader.createCompactedResource({
-      '@id': 'ex:myOverride2',
-      types: 'oo:Override',
-      overrideInstance: 'ex:myOverride1',
-      overrideParameters: {
-        '@type': 'ex:ExtraType',
-        'ex:param3': '"value3"',
-        'ex:param4': '"value4"',
-      },
-    });
-    const overrideInstance3 = objectLoader.createCompactedResource({
-      '@id': 'ex:myOverride3',
-      types: 'oo:Override',
-      overrideInstance: 'ex:myOverride2',
-      overrideParameters: {
-        'ex:param4': '"value4-2"',
-      },
-    });
-    const override2Properties = overrideInstance2.properties[IRIS_OO.overrideParameters][0].properties;
-    const override3Properties = overrideInstance3.properties[IRIS_OO.overrideParameters][0].properties;
-    const override = preprocessor.canHandle(config)!;
-    const { rawConfig, finishTransformation } = preprocessor.transform(config, override);
-    expect(finishTransformation).toBe(false);
-    expect(rawConfig).toBe(config);
-    expect(rawConfig.properties['ex:param1']).toHaveLength(0);
-    expect(rawConfig.properties['ex:param2']).toHaveLength(0);
-    expect(rawConfig.properties['ex:param3'][0]).toBe(override2Properties['ex:param3'][0]);
-    expect(rawConfig.properties['ex:param3'][0].value).toBe('value3');
-    expect(rawConfig.properties['ex:param4'][0]).toBe(override3Properties['ex:param4'][0]);
-    expect(rawConfig.properties['ex:param4'][0].value).toBe('value4-2');
+    const override = preprocessor.canHandle(config);
+    expect(() => preprocessor.transform(config, override!)).toThrow(`Found no handler supporting an override step of type UnknownOverride`);
   });
 });

--- a/test/unit/preprocess/overrideSteps/OverrideListInsertAfter-test.ts
+++ b/test/unit/preprocess/overrideSteps/OverrideListInsertAfter-test.ts
@@ -1,0 +1,78 @@
+import { DataFactory } from 'rdf-data-factory';
+import type { RdfObjectLoader, Resource } from 'rdf-object';
+import { OverrideListInsertAfter } from '../../../../lib/preprocess/overridesteps/OverrideListInsertAfter';
+import { setupObjectLoader } from './OverrideTestUtil';
+
+const DF = new DataFactory();
+
+describe('OverrideListInsertAfter', (): void => {
+  let objectLoader: RdfObjectLoader;
+  let config: Resource;
+  const stepHandler = new OverrideListInsertAfter();
+
+  beforeEach(async() => {
+    objectLoader = await setupObjectLoader();
+
+    config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+      types: 'ex:Component',
+      'ex:param1': '"value1"',
+      'ex:paramList': {
+        list: [ '"list1"', '"list2"', '"list3"', '"list4"' ],
+      },
+    });
+  });
+
+  it('can only handle OverrideListInsertAfter steps.', async(): Promise<void> => {
+    let step = objectLoader.createCompactedResource({ types: 'oo:OverrideListInsertAfter' });
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+
+    step = objectLoader.createCompactedResource({ types: 'oo:OverrideUnknown' });
+    expect(stepHandler.canHandle(config, step)).toBe(false);
+  });
+
+  it('can insert in lists after a specified element.', () => {
+    const step = objectLoader.createCompactedResource({
+      types: 'oo:OverrideListInsertAfter',
+      overrideParameter: { '@id': 'ex:paramList' },
+      overrideTarget: '"list2"',
+      overrideValue: '"newList"',
+    });
+
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+    expect(stepHandler.handle(config, step)).toBe(config);
+
+    expect(config.properties['ex:param1'][0].value).toBe('value1');
+    expect(config.properties['ex:paramList'][0].list?.map(res => res.term))
+      .toEqual([
+        DF.literal('list1'),
+        DF.literal('list2'),
+        DF.literal('newList'),
+        DF.literal('list3'),
+        DF.literal('list4'),
+      ]);
+  });
+
+  it('can insert multiple values after a specified element.', () => {
+    const step = objectLoader.createCompactedResource({
+      types: 'oo:OverrideListInsertAfter',
+      overrideParameter: { '@id': 'ex:paramList' },
+      overrideTarget: '"list4"',
+      overrideValue: { list: [ '"newList"', '"newList2"' ]},
+    });
+
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+    expect(stepHandler.handle(config, step)).toBe(config);
+
+    expect(config.properties['ex:param1'][0].value).toBe('value1');
+    expect(config.properties['ex:paramList'][0].list?.map(res => res.term))
+      .toEqual([
+        DF.literal('list1'),
+        DF.literal('list2'),
+        DF.literal('list3'),
+        DF.literal('list4'),
+        DF.literal('newList'),
+        DF.literal('newList2'),
+      ]);
+  });
+});

--- a/test/unit/preprocess/overrideSteps/OverrideListInsertAt-test.ts
+++ b/test/unit/preprocess/overrideSteps/OverrideListInsertAt-test.ts
@@ -1,0 +1,157 @@
+import { DataFactory } from 'rdf-data-factory';
+import type { RdfObjectLoader, Resource } from 'rdf-object';
+import { OverrideListInsertAt } from '../../../../lib/preprocess/overridesteps/OverrideListInsertAt';
+import { setupObjectLoader } from './OverrideTestUtil';
+
+const DF = new DataFactory();
+
+describe('OverrideListInsertAt', (): void => {
+  let objectLoader: RdfObjectLoader;
+  let config: Resource;
+  const stepHandler = new OverrideListInsertAt();
+
+  beforeEach(async() => {
+    objectLoader = await setupObjectLoader();
+
+    config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+      types: 'ex:Component',
+      'ex:param1': '"value1"',
+      'ex:paramList': {
+        list: [ '"list1"', '"list2"', '"list3"', '"list4"' ],
+      },
+    });
+  });
+
+  it('can only handle OverrideListInsertAt steps.', async(): Promise<void> => {
+    let step = objectLoader.createCompactedResource({ types: 'oo:OverrideListInsertAt' });
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+
+    step = objectLoader.createCompactedResource({ types: 'oo:OverrideUnknown' });
+    expect(stepHandler.canHandle(config, step)).toBe(false);
+  });
+
+  it('can insert in lists at a specified index.', () => {
+    const step = objectLoader.createCompactedResource({
+      types: 'oo:OverrideListInsertAt',
+      overrideParameter: { '@id': 'ex:paramList' },
+      overrideTarget: '"0"',
+      overrideValue: '"newList"',
+    });
+
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+    expect(stepHandler.handle(config, step)).toBe(config);
+
+    expect(config.properties['ex:param1'][0].value).toBe('value1');
+    expect(config.properties['ex:paramList'][0].list?.map(res => res.term))
+      .toEqual([
+        DF.literal('newList'),
+        DF.literal('list1'),
+        DF.literal('list2'),
+        DF.literal('list3'),
+        DF.literal('list4'),
+      ]);
+  });
+
+  it('can insert multiple values at a specified index.', () => {
+    const step = objectLoader.createCompactedResource({
+      types: 'oo:OverrideListInsertAt',
+      overrideParameter: { '@id': 'ex:paramList' },
+      overrideTarget: '"1"',
+      overrideValue: { list: [ '"newList"', '"newList2"' ]},
+    });
+
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+    expect(stepHandler.handle(config, step)).toBe(config);
+
+    expect(config.properties['ex:param1'][0].value).toBe('value1');
+    expect(config.properties['ex:paramList'][0].list?.map(res => res.term))
+      .toEqual([
+        DF.literal('list1'),
+        DF.literal('newList'),
+        DF.literal('newList2'),
+        DF.literal('list2'),
+        DF.literal('list3'),
+        DF.literal('list4'),
+      ]);
+  });
+
+  it('supports a negative index.', async(): Promise<void> => {
+    const step = objectLoader.createCompactedResource({
+      types: 'oo:OverrideListInsertAt',
+      overrideParameter: { '@id': 'ex:paramList' },
+      overrideTarget: '"-1"',
+      overrideValue: '"newList"',
+    });
+
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+    expect(stepHandler.handle(config, step)).toBe(config);
+
+    expect(config.properties['ex:param1'][0].value).toBe('value1');
+    expect(config.properties['ex:paramList'][0].list?.map(res => res.term))
+      .toEqual([
+        DF.literal('list1'),
+        DF.literal('list2'),
+        DF.literal('list3'),
+        DF.literal('newList'),
+        DF.literal('list4'),
+      ]);
+  });
+
+  it('supports a negative zero index to insert at the end of the list.', async(): Promise<void> => {
+    const step = objectLoader.createCompactedResource({
+      types: 'oo:OverrideListInsertAt',
+      overrideParameter: { '@id': 'ex:paramList' },
+      overrideTarget: '"-0"',
+      overrideValue: '"newList"',
+    });
+
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+    expect(stepHandler.handle(config, step)).toBe(config);
+
+    expect(config.properties['ex:param1'][0].value).toBe('value1');
+    expect(config.properties['ex:paramList'][0].list?.map(res => res.term))
+      .toEqual([
+        DF.literal('list1'),
+        DF.literal('list2'),
+        DF.literal('list3'),
+        DF.literal('list4'),
+        DF.literal('newList'),
+      ]);
+  });
+
+  it('adds elements to the end of the list if the index is too large.', async(): Promise<void> => {
+    const step = objectLoader.createCompactedResource({
+      types: 'oo:OverrideListInsertAt',
+      overrideParameter: { '@id': 'ex:paramList' },
+      overrideTarget: '"5"',
+      overrideValue: '"newList"',
+    });
+
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+    expect(stepHandler.handle(config, step)).toBe(config);
+
+    expect(config.properties['ex:param1'][0].value).toBe('value1');
+    expect(config.properties['ex:paramList'][0].list?.map(res => res.term))
+      .toEqual([
+        DF.literal('list1'),
+        DF.literal('list2'),
+        DF.literal('list3'),
+        DF.literal('list4'),
+        DF.literal('newList'),
+      ]);
+  });
+
+  it('errors on invalid index values.', async(): Promise<void> => {
+    const step = objectLoader.createCompactedResource({
+      types: 'oo:OverrideListInsertAt',
+      overrideParameter: { '@id': 'ex:paramList' },
+      overrideTarget: '"5a"',
+      overrideValue: '"newList"',
+    });
+
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+    expect(() => stepHandler.handle(config, step))
+      .toThrow('Invalid index in Override step OverrideListInsertAt for parameter ex:paramList: 5a');
+  });
+});

--- a/test/unit/preprocess/overrideSteps/OverrideListInsertBefore-test.ts
+++ b/test/unit/preprocess/overrideSteps/OverrideListInsertBefore-test.ts
@@ -1,0 +1,78 @@
+import { DataFactory } from 'rdf-data-factory';
+import type { RdfObjectLoader, Resource } from 'rdf-object';
+import { OverrideListInsertBefore } from '../../../../lib/preprocess/overridesteps/OverrideListInsertBefore';
+import { setupObjectLoader } from './OverrideTestUtil';
+
+const DF = new DataFactory();
+
+describe('OverrideListInsertBefore', (): void => {
+  let objectLoader: RdfObjectLoader;
+  let config: Resource;
+  const stepHandler = new OverrideListInsertBefore();
+
+  beforeEach(async() => {
+    objectLoader = await setupObjectLoader();
+
+    config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+      types: 'ex:Component',
+      'ex:param1': '"value1"',
+      'ex:paramList': {
+        list: [ '"list1"', '"list2"', '"list3"', '"list4"' ],
+      },
+    });
+  });
+
+  it('can only handle OverrideListInsertBefore steps.', async(): Promise<void> => {
+    let step = objectLoader.createCompactedResource({ types: 'oo:OverrideListInsertBefore' });
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+
+    step = objectLoader.createCompactedResource({ types: 'oo:OverrideUnknown' });
+    expect(stepHandler.canHandle(config, step)).toBe(false);
+  });
+
+  it('can insert in lists after a specific element.', () => {
+    const step = objectLoader.createCompactedResource({
+      types: 'oo:OverrideListInsertBefore',
+      overrideParameter: { '@id': 'ex:paramList' },
+      overrideTarget: '"list2"',
+      overrideValue: '"newList"',
+    });
+
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+    expect(stepHandler.handle(config, step)).toBe(config);
+
+    expect(config.properties['ex:param1'][0].value).toBe('value1');
+    expect(config.properties['ex:paramList'][0].list?.map(res => res.term))
+      .toEqual([
+        DF.literal('list1'),
+        DF.literal('newList'),
+        DF.literal('list2'),
+        DF.literal('list3'),
+        DF.literal('list4'),
+      ]);
+  });
+
+  it('can insert multiple values after a specific element.', () => {
+    const step = objectLoader.createCompactedResource({
+      types: 'oo:OverrideListInsertBefore',
+      overrideParameter: { '@id': 'ex:paramList' },
+      overrideTarget: '"list4"',
+      overrideValue: { list: [ '"newList"', '"newList2"' ]},
+    });
+
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+    expect(stepHandler.handle(config, step)).toBe(config);
+
+    expect(config.properties['ex:param1'][0].value).toBe('value1');
+    expect(config.properties['ex:paramList'][0].list?.map(res => res.term))
+      .toEqual([
+        DF.literal('list1'),
+        DF.literal('list2'),
+        DF.literal('list3'),
+        DF.literal('newList'),
+        DF.literal('newList2'),
+        DF.literal('list4'),
+      ]);
+  });
+});

--- a/test/unit/preprocess/overrideSteps/OverrideListRemove-test.ts
+++ b/test/unit/preprocess/overrideSteps/OverrideListRemove-test.ts
@@ -1,0 +1,70 @@
+import { DataFactory } from 'rdf-data-factory';
+import type { RdfObjectLoader, Resource } from 'rdf-object';
+import { OverrideListRemove } from '../../../../lib/preprocess/overridesteps/OverrideListRemove';
+import { setupObjectLoader } from './OverrideTestUtil';
+
+const DF = new DataFactory();
+
+describe('OverrideListRemove', (): void => {
+  let objectLoader: RdfObjectLoader;
+  let config: Resource;
+  const stepHandler = new OverrideListRemove();
+
+  beforeEach(async() => {
+    objectLoader = await setupObjectLoader();
+
+    config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+      types: 'ex:Component',
+      'ex:param1': '"value1"',
+      'ex:paramList': {
+        list: [ '"list1"', '"list2"', '"list3"', '"list4"' ],
+      },
+    });
+  });
+
+  it('can only handle OverrideListRemove steps.', async(): Promise<void> => {
+    let step = objectLoader.createCompactedResource({ types: 'oo:OverrideListRemove' });
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+
+    step = objectLoader.createCompactedResource({ types: 'oo:OverrideUnknown' });
+    expect(stepHandler.canHandle(config, step)).toBe(false);
+  });
+
+  it('can remove a specific element.', () => {
+    const step = objectLoader.createCompactedResource({
+      types: 'oo:OverrideListRemove',
+      overrideParameter: { '@id': 'ex:paramList' },
+      overrideTarget: '"list2"',
+    });
+
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+    expect(stepHandler.handle(config, step)).toBe(config);
+
+    expect(config.properties['ex:param1'][0].value).toBe('value1');
+    expect(config.properties['ex:paramList'][0].list?.map(res => res.term))
+      .toEqual([
+        DF.literal('list1'),
+        DF.literal('list3'),
+        DF.literal('list4'),
+      ]);
+  });
+
+  it('can remove multiple elements.', () => {
+    const step = objectLoader.createCompactedResource({
+      types: 'oo:OverrideListRemove',
+      overrideParameter: { '@id': 'ex:paramList' },
+      overrideTarget: { list: [ '"list2"', '"list4"' ]},
+    });
+
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+    expect(stepHandler.handle(config, step)).toBe(config);
+
+    expect(config.properties['ex:param1'][0].value).toBe('value1');
+    expect(config.properties['ex:paramList'][0].list?.map(res => res.term))
+      .toEqual([
+        DF.literal('list1'),
+        DF.literal('list3'),
+      ]);
+  });
+});

--- a/test/unit/preprocess/overrideSteps/OverrideMapEntry-test.ts
+++ b/test/unit/preprocess/overrideSteps/OverrideMapEntry-test.ts
@@ -1,0 +1,137 @@
+import type { Term } from '@rdfjs/types';
+import { DataFactory } from 'rdf-data-factory';
+import type { Resource, RdfObjectLoader } from 'rdf-object';
+import { OverrideMapEntry } from '../../../../lib/preprocess/overridesteps/OverrideMapEntry';
+import { setupObjectLoader } from './OverrideTestUtil';
+
+const DF = new DataFactory();
+
+describe('OverrideMapEntry', (): void => {
+  let objectLoader: RdfObjectLoader;
+  let config: Resource;
+  const stepHandler = new OverrideMapEntry();
+
+  beforeEach(async() => {
+    objectLoader = await setupObjectLoader();
+
+    config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+      types: 'ex:Component',
+      'ex:param1': '"value1"',
+      'ex:paramMap': {
+        list: [
+          {
+            'ex:paramMap_key': '"key"',
+            'ex:paramMap_value': '"value"',
+          },
+          {
+            'ex:paramMap_key': '"key2"',
+            'ex:paramMap_value': '"value2"',
+          },
+        ],
+      },
+    });
+  });
+
+  it('can only handle OverrideMapEntry steps.', async(): Promise<void> => {
+    let step = objectLoader.createCompactedResource({ types: 'oo:OverrideMapEntry' });
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+
+    step = objectLoader.createCompactedResource({ types: 'oo:OverrideUnknown' });
+    expect(stepHandler.canHandle(config, step)).toBe(false);
+  });
+
+  it('can replace the value of a key in a key/value object.', async(): Promise<void> => {
+    const step = objectLoader.createCompactedResource({
+      types: 'oo:OverrideMapEntry',
+      overrideParameter: { '@id': 'ex:paramMap' },
+      overrideTarget: '"key"',
+      overrideValue: '"newValue"',
+    });
+
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+    expect(stepHandler.handle(config, step)).toBe(config);
+
+    expect(config.property['ex:param1'].value).toBe('value1');
+    const entryList = config.property['ex:paramMap'].list;
+    const entries = entryList?.map((entry): { key: Term; value: Term } => ({
+      key: entry.property['ex:paramMap_key'].term,
+      value: entry.property['ex:paramMap_value'].term,
+    }));
+    expect(entries).toEqual([
+      { key: DF.literal('key'), value: DF.literal('newValue') },
+      { key: DF.literal('key2'), value: DF.literal('value2') },
+    ]);
+  });
+
+  it('can remove an entry in a key/value object.', async(): Promise<void> => {
+    const step = objectLoader.createCompactedResource({
+      types: 'oo:OverrideMapEntry',
+      overrideParameter: { '@id': 'ex:paramMap' },
+      overrideTarget: '"key"',
+    });
+
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+    expect(stepHandler.handle(config, step)).toBe(config);
+
+    expect(config.property['ex:param1'].value).toBe('value1');
+    const entryList = config.property['ex:paramMap'].list;
+    const entries = entryList?.map((entry): { key: Term; value: Term } => ({
+      key: entry.property['ex:paramMap_key'].term,
+      value: entry.property['ex:paramMap_value'].term,
+    }));
+    expect(entries).toEqual([
+      { key: DF.literal('key2'), value: DF.literal('value2') },
+    ]);
+  });
+
+  it('throws an error if the predicate does not point to a key/value map.', async(): Promise<void> => {
+    const step = objectLoader.createCompactedResource({
+      types: 'oo:OverrideMapEntry',
+      overrideParameter: { '@id': 'ex:paramList' },
+      overrideTarget: '"key"',
+    });
+
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+    expect(() => stepHandler.handle(config, step)).toThrow('Unable to find key/value URIs for parameter ex:paramList');
+  });
+
+  it('throw an error if no key/value entry could be found with the given key.', async(): Promise<void> => {
+    const step = objectLoader.createCompactedResource({
+      types: 'oo:OverrideMapEntry',
+      overrideParameter: { '@id': 'ex:paramMap' },
+      overrideTarget: '"wrongKey"',
+    });
+
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+    expect(() => stepHandler.handle(config, step)).toThrow('Unable to find key/value entry with key wrongKey');
+  });
+
+  it('errors if constructor fields could not be found.', async(): Promise<void> => {
+    const component = objectLoader.getOrMakeResource(DF.namedNode('ex:Component'));
+    delete component.property.constructorArguments.list![0].property.fields.list;
+
+    const step = objectLoader.createCompactedResource({
+      types: 'oo:OverrideMapEntry',
+      overrideParameter: { '@id': 'ex:paramMap' },
+      overrideTarget: '"key"',
+    });
+
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+    expect(() => stepHandler.handle(config, step)).toThrow('Unable to find key/value URIs for parameter ex:paramMap');
+  });
+
+  it('errors if constructor arguments could not be found.', async(): Promise<void> => {
+    const component = objectLoader.getOrMakeResource(DF.namedNode('ex:Component'));
+    delete component.property.constructorArguments.list;
+
+    const step = objectLoader.createCompactedResource({
+      types: 'oo:OverrideMapEntry',
+      overrideParameter: { '@id': 'ex:paramMap' },
+      overrideTarget: '"key"',
+    });
+
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+    expect(() => stepHandler.handle(config, step)).toThrow('Unable to find key/value URIs for parameter ex:paramMap');
+  });
+});

--- a/test/unit/preprocess/overrideSteps/OverrideParameters-test.ts
+++ b/test/unit/preprocess/overrideSteps/OverrideParameters-test.ts
@@ -1,0 +1,63 @@
+import { DataFactory } from 'rdf-data-factory';
+import type { RdfObjectLoader, Resource } from 'rdf-object';
+import { OverrideParameters } from '../../../../lib/preprocess/overridesteps/OverrideParameters';
+import { setupObjectLoader } from './OverrideTestUtil';
+
+const DF = new DataFactory();
+
+describe('OverrideParameters', (): void => {
+  let objectLoader: RdfObjectLoader;
+  let config: Resource;
+  const stepHandler = new OverrideParameters();
+
+  beforeEach(async() => {
+    objectLoader = await setupObjectLoader();
+
+    config = objectLoader.createCompactedResource({
+      '@id': 'ex:myComponentInstance',
+      types: 'ex:Component',
+      'ex:param1': '"value1"',
+      'ex:param2': '"value2"',
+    });
+  });
+
+  it('can only handle OverrideParameters steps.', async(): Promise<void> => {
+    let step = objectLoader.createCompactedResource({ types: 'oo:OverrideParameters' });
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+
+    step = objectLoader.createCompactedResource({ types: 'oo:OverrideUnknown' });
+    expect(stepHandler.canHandle(config, step)).toBe(false);
+  });
+
+  it('can override parameters.', async(): Promise<void> => {
+    const step = objectLoader.createCompactedResource({
+      types: 'oo:OverrideParameters',
+      overrideValue: {
+        'ex:param1': '"updatedValue"',
+      },
+    });
+
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+    expect(stepHandler.handle(config, step)).toBe(config);
+
+    expect(config.properties['ex:param1'][0].term).toEqual(DF.literal('updatedValue'));
+    expect(config.properties['ex:param2'][0].term).toEqual(DF.literal('value2'));
+  });
+
+  it('can replace the type of an object.', async(): Promise<void> => {
+    const step = objectLoader.createCompactedResource({
+      types: 'oo:OverrideParameters',
+      overrideValue: {
+        '@type': 'ex:ExtraType',
+        'ex:param3': '"hello"',
+      },
+    });
+
+    expect(stepHandler.canHandle(config, step)).toBe(true);
+    expect(stepHandler.handle(config, step)).toBe(config);
+
+    expect(config.properties['ex:param3'][0].term).toEqual(DF.literal('hello'));
+    expect(config.properties['ex:param1']).toHaveLength(0);
+    expect(config.properties['ex:param2']).toHaveLength(0);
+  });
+});

--- a/test/unit/preprocess/overrideSteps/OverrideTestUtil.ts
+++ b/test/unit/preprocess/overrideSteps/OverrideTestUtil.ts
@@ -1,0 +1,41 @@
+import * as fs from 'fs';
+import { RdfObjectLoader } from 'rdf-object';
+
+/**
+ * Creates an object loader and creates the definition of a dummy class.
+ */
+export async function setupObjectLoader(): Promise<RdfObjectLoader> {
+  const objectLoader = new RdfObjectLoader({
+    uniqueLiterals: true,
+    context: JSON.parse(fs.readFileSync(`${__dirname}/../../../../components/context.jsonld`, 'utf8')),
+  });
+  await objectLoader.context;
+
+  objectLoader.createCompactedResource({
+    '@id': 'ex:Component',
+    module: 'ex:Module',
+    parameters: [
+      { '@id': 'ex:param1' },
+      { '@id': 'ex:param2' },
+      { '@id': 'ex:paramList' },
+      { '@id': 'ex:paramMap' },
+    ],
+    constructorArguments: {
+      list: [{
+        fields: {
+          list: [{
+            collectEntries: { list: [ 'ex:paramMap' ]},
+            key: 'ex:paramMap_key',
+            value: 'ex:paramMap_value',
+          }],
+        },
+      }],
+    },
+  });
+  objectLoader.createCompactedResource({
+    '@id': 'ex:ExtraType',
+    module: 'ex:Module',
+  });
+
+  return objectLoader;
+}

--- a/test/unit/preprocess/overrideSteps/OverrideUtil-test.ts
+++ b/test/unit/preprocess/overrideSteps/OverrideUtil-test.ts
@@ -1,0 +1,141 @@
+import 'jest-rdf';
+import { DataFactory } from 'rdf-data-factory';
+import type { RdfObjectLoader, Resource } from 'rdf-object';
+import {
+  extractOverrideStepFields, findResourceIndex,
+  getPropertyResourceList,
+} from '../../../../lib/preprocess/overridesteps/OverrideUtil';
+import { setupObjectLoader } from './OverrideTestUtil';
+
+const DF = new DataFactory();
+
+describe('OverrideUtil', (): void => {
+  let objectLoader: RdfObjectLoader;
+
+  beforeEach(async(): Promise<void> => {
+    objectLoader = await setupObjectLoader();
+  });
+
+  describe('#extractOverrideStepFields', (): void => {
+    it('extracts the necessary fields.', async(): Promise<void> => {
+      const step = objectLoader.createCompactedResource({
+        types: 'oo:OverrideListInsertAt',
+        overrideParameter: { '@id': 'ex:paramList' },
+        overrideValue: { list: [ '"newList"', '"newList2"' ]},
+      });
+
+      const result = extractOverrideStepFields(step, { parameters: 1, targets: 0, values: 2 });
+      expect(result.parameters).toHaveLength(1);
+      expect(result.parameters[0].term).toEqual(DF.namedNode('ex:paramList'));
+      expect(result.targets).toHaveLength(0);
+      expect(result.values).toHaveLength(2);
+      expect(result.values[0].term).toEqual(DF.literal('newList'));
+      expect(result.values[1].term).toEqual(DF.literal('newList2'));
+    });
+
+    it('errors if there are multiple field values without using a list.', async(): Promise<void> => {
+      const step = objectLoader.createCompactedResource({
+        types: 'oo:OverrideListInsertAt',
+        overrideParameter: { '@id': 'ex:paramList' },
+        overrideValue: [ '"newList"', '"newList2"' ],
+      });
+
+      expect(() => extractOverrideStepFields(step))
+        .toThrow('Detected multiple values for overrideValue in Override step');
+    });
+
+    it('errors if one of the expected counts does not match the actual count.', async(): Promise<void> => {
+      const step = objectLoader.createCompactedResource({
+        types: 'oo:OverrideListInsertAt',
+        overrideParameter: { '@id': 'ex:paramList' },
+        overrideValue: { list: [ '"newList"', '"newList2"' ]},
+      });
+
+      expect(() => extractOverrideStepFields(step, { values: 3 }))
+        .toThrow('Expected 3 entries for overrideValue but found 2 in Override step');
+    });
+  });
+
+  describe('#getPropertyResourceList', (): void => {
+    let parameter: Resource;
+
+    beforeAll(async(): Promise<void> => {
+      parameter = objectLoader.getOrMakeResource(DF.namedNode('ex:param1'));
+    });
+
+    it('combines all results in a single list.', async(): Promise<void> => {
+      const config = objectLoader.createCompactedResource({
+        '@id': 'ex:myComponentInstance',
+        types: 'ex:Component',
+        'ex:param1': [{ list: [ '"value1"' ]}, { list: [ '"value2"', '"value3"' ]}],
+      });
+      const list = getPropertyResourceList(config, parameter);
+      expect(list).toHaveLength(3);
+      expect(list.map(entry => entry.term)).toEqualRdfTermArray([
+        DF.literal('value1'), DF.literal('value2'), DF.literal('value3'),
+      ]);
+    });
+
+    it('returns an empty list if the parameter is empty.', async(): Promise<void> => {
+      const config = objectLoader.createCompactedResource({
+        '@id': 'ex:myComponentInstance',
+        types: 'ex:Component',
+      });
+      const list = getPropertyResourceList(config, parameter);
+      expect(list).toHaveLength(0);
+    });
+
+    it('errors if a non-list resource is found.', async(): Promise<void> => {
+      const config = objectLoader.createCompactedResource({
+        '@id': 'ex:myComponentInstance',
+        types: 'ex:Component',
+        'ex:param1': [{ list: [ '"value1"' ]}, [ '"value2"', '"value3"' ]],
+      });
+      expect(() => getPropertyResourceList(config, parameter)).toThrow(
+        'Invalid target in Override step targeting ex:myComponentInstance: ex:param1 does not reference a list',
+      );
+    });
+
+    it('assigns the list to the original resource so it can be updated there.', async(): Promise<void> => {
+      const config = objectLoader.createCompactedResource({
+        '@id': 'ex:myComponentInstance',
+        types: 'ex:Component',
+        'ex:param1': [{ list: [ '"value1"' ]}, { list: [ '"value2"', '"value3"' ]}],
+      });
+
+      getPropertyResourceList(config, parameter);
+      const list = config.property['ex:param1'].list;
+      expect(list).toBeDefined();
+      expect(list).toHaveLength(3);
+      expect(list!.map(entry => entry.term)).toEqualRdfTermArray([
+        DF.literal('value1'), DF.literal('value2'), DF.literal('value3'),
+      ]);
+
+      list!.splice(1, 1);
+      expect(list).toHaveLength(2);
+      expect(list!.map(entry => entry.term)).toEqualRdfTermArray([
+        DF.literal('value1'), DF.literal('value3'),
+      ]);
+    });
+  });
+
+  describe('#findResourceInList', (): void => {
+    let list: Resource[];
+
+    beforeAll(async(): Promise<void> => {
+      list = [
+        objectLoader.createCompactedResource('"value1"'),
+        objectLoader.createCompactedResource('"value2"'),
+      ];
+    });
+
+    it('finds the matching resource in a list.', async(): Promise<void> => {
+      expect(findResourceIndex(list, objectLoader.createCompactedResource('"value2"'))).toBe(1);
+    });
+
+    it('errors if the resource can not be found.', async(): Promise<void> => {
+      expect(() => findResourceIndex(list, objectLoader.createCompactedResource('"unknown"')))
+        .toThrow('Unable to find unknown in targeted list while overriding.');
+    });
+  });
+});


### PR DESCRIPTION
Closes https://github.com/LinkedSoftwareDependencies/Components.js/issues/129

Implements what is described in https://github.com/LinkedSoftwareDependencies/Components.js/issues/129#issuecomment-1814630077

Will look into documentation when this is accepted.

Some of the behaviour that happened in the `canHandle` of the `ConfigPreprocessorOverride` was moved to the `transform` call, but this should not have an impact.