### PR TITLE
bug: Update context URL to version 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.4.0",
   "description": "A semantic dependency injection framework",
   "lsd:contexts": {
-    "https://linkedsoftwaredependencies.org/bundles/npm/componentsjs/^5.0.0/components/context.jsonld": "components/context.jsonld"
+    "https://linkedsoftwaredependencies.org/bundles/npm/componentsjs/^6.0.0/components/context.jsonld": "components/context.jsonld"
   },
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
This should've been updated to 6.0.0 with the major version bump