### PR TITLE
fix(ci): only submit coverage from ubuntu (macOS runner rejects the coveralls Homebrew tap)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Run webpack
         run: yarn run test:webpack
       - name: Submit coverage results
+        if: matrix.os == 'ubuntu-latest'
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}


### PR DESCRIPTION
> **Note:** This PR was opened by @jeswr's AI agent and is intended for @jeswr to review before it goes to the maintainers. cc @jeswr

## The break

Since **2026-07-03**, CI is red on **every PR and on `master`** for this repo — even though the build, all 865 tests (100% coverage), and webpack all pass.

The cause is not any PR. GitHub's **macOS** runners now **refuse to load the untrusted `coverallsapp/coveralls` Homebrew tap** (a Homebrew policy change: *"Refusing to load formula … from untrusted tap"*). The `test` matrix job runs on `ubuntu-latest`, `windows-latest`, and `macos-latest`, and its **"Submit coverage results"** step uses `coverallsapp/github-action@v2`. On macOS that step now fails, and because the matrix is fail-fast, the failure **cancels the rest of the matrix** → the whole workflow shows red despite everything passing.

## The fix

Scope the "Submit coverage results" step to `ubuntu-latest` only:

```diff
       - name: Submit coverage results
+        if: matrix.os == 'ubuntu-latest'
         uses: coverallsapp/github-action@v2
```

Coverage from a single OS is sufficient, and this also sidesteps per-node-version flag-name collisions across operating systems. The separate `coveralls` finish job (`runs-on: ubuntu-latest`) is unchanged.

This is a one-line change that **unblocks CI for the entire repository**.

## Next steps

@jeswr will review, mark this ready, and tag the maintainers.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)



> **Review timing:** This draft was prepared with Claude; I (@jeswr) will personally review it before it progresses. I'm currently batching a lot of work in flight, so expect active review Wednesday–Friday (8–10 July).